### PR TITLE
Fix ARM64 DYNAMIC_ARCH unconditionally branching into the SME code for STRMM

### DIFF
--- a/interface/symm.c
+++ b/interface/symm.c
@@ -374,6 +374,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_SIDE Side, enum CBLAS_UPLO Uplo,
     return;
   }
 
+   if (args.m == 0 || args.n == 0) return;
 #if !defined(COMPLEX) && !defined(DOUBLE) && !defined(BFLOAT16)  && !defined(HFLOAT16)
 #if defined(ARCH_ARM64) && (defined(USE_SSYMM_KERNEL_DIRECT)||defined(DYNAMIC_ARCH))
 #if defined(DYNAMIC_ARCH)
@@ -383,7 +384,6 @@ if (strcmp(gotoblas_corename(), "armv9sme") == 0
 #endif
 )
 #endif
-   if (args.m == 0 || args.n == 0) return;
    if (order == CblasRowMajor && m == lda && n == ldb && n == ldc)
    {
      if (Side == CblasLeft && Uplo == CblasUpper) {
@@ -397,8 +397,6 @@ if (strcmp(gotoblas_corename(), "armv9sme") == 0
 #endif
 
 #endif
-
-  if (args.m == 0 || args.n == 0) return;
 
   IDEBUG_START;
 

--- a/interface/trsm.c
+++ b/interface/trsm.c
@@ -383,8 +383,6 @@ if (strcmp(gotoblas_corename(), "armv9sme") == 0
 
 #endif
 
-  if ((args.m == 0) || (args.n == 0)) return;
-
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();

--- a/interface/trsm.c
+++ b/interface/trsm.c
@@ -359,6 +359,8 @@ void CNAME(enum CBLAS_ORDER order,
     return;
   }
 
+  if (args.m == 0 || args.n == 0) return;
+
 #if !defined(COMPLEX) && !defined(DOUBLE) && !defined(BFLOAT16)  && !defined(HFLOAT16)
 #if defined(ARCH_ARM64) && (defined(USE_STRMM_KERNEL_DIRECT)||defined(DYNAMIC_ARCH))
 #if defined(DYNAMIC_ARCH)
@@ -368,7 +370,6 @@ if (strcmp(gotoblas_corename(), "armv9sme") == 0
 #endif
 )
 #endif
-  if (args.m == 0 || args.n == 0) return;
   if (order == CblasRowMajor && Diag == CblasNonUnit && Side == CblasLeft && m == lda && n == ldb) {
     if (Trans ==  CblasNoTrans) {
       (Uplo == CblasUpper ? STRMM_DIRECT_LNUN : STRMM_DIRECT_LNLN)(m, n, alpha, a, lda, b, ldb);


### PR DESCRIPTION
fixes #5763 by moving the unrelated quick return that had become the spurious target of the corename check