### PR TITLE
Fix compilation with DYNAMIC_TARGET=1 and BUILD_BFLOAT16

### DIFF
--- a/driver/others/dynamic_riscv64.c
+++ b/driver/others/dynamic_riscv64.c
@@ -152,6 +152,7 @@ char* gotoblas_corename(void) {
 static gotoblas_t* get_coretype(void) {
 	uint64_t vector_mask;
 	unsigned vlenb = 0;
+	char coremsg[128];
 
 #if !defined(OS_LINUX)
 	return NULL;


### PR DESCRIPTION
coremsg isn't defined outside the BUILD_BFLOAT16 and BUILD_HFLOAT16 blocks, leading to the use of an undefined variable