### PR TITLE
Correct offsets in PowerPC SCAL assembly under FreeBSD and re-enable for PPC970

### DIFF
--- a/kernel/power/KERNEL.PPC970
+++ b/kernel/power/KERNEL.PPC970
@@ -90,9 +90,3 @@ CROTKERNEL   = ../arm/zrot.c
 ZROTKERNEL   = ../arm/zrot.c
 endif
 
-ifeq ($(OSNAME), FreeBSD)
-SSCALKERNEL  = ../arm/scal.c
-DSCALKERNEL  = ../arm/scal.c
-CSCALKERNEL  = ../arm/zscal.c
-ZSCALKERNEL  = ../arm/zscal.c
-endif

--- a/kernel/power/scal.S
+++ b/kernel/power/scal.S
@@ -91,8 +91,12 @@
 	fcmpu	cr0, FZERO, ALPHA
 	bne-	cr0, LL(A1I1)
 
-	LDLONG  FLAG,    120(SP)
-	cmpwi   cr0, FLAG, 1
+#ifdef (__FreeBSD__)
+    LDLONG  FLAG, 104(SP)
+#else
+    LDLONG  FLAG, 120(SP)
+#endif
+    cmpwi   cr0, FLAG, 1
 	beq-   cr0, LL(A1I1)
 
 	cmpwi	cr0, INCX, SIZE

--- a/kernel/power/scal.S
+++ b/kernel/power/scal.S
@@ -91,7 +91,7 @@
 	fcmpu	cr0, FZERO, ALPHA
 	bne-	cr0, LL(A1I1)
 
-#ifdef (__FreeBSD__)
+#if defined(__FreeBSD__)
     LDLONG  FLAG, 104(SP)
 #else
     LDLONG  FLAG, 120(SP)

--- a/kernel/power/zscal.S
+++ b/kernel/power/zscal.S
@@ -96,7 +96,11 @@
 	fcmpu	cr0, FZERO, ALPHA_I
 	bne-	cr0, LL(A1I1)
 
+#if defined(__FreeBSD__)
+    LDLONG  FLAG, 112(SP)
+#else
 	LDLONG	FLAG, 128(SP)
+#endif
 	cmpwi	cr0, FLAG, 1
 	beq-	cr0, LL(A1I1)
 


### PR DESCRIPTION
should fix #5627 for good