### PR TITLE
Fix Apple platform detection and iOS cross-build

### DIFF
--- a/.github/workflows/apple_m.yml
+++ b/.github/workflows/apple_m.yml
@@ -244,15 +244,12 @@ jobs:
 
       - name: Crossbuild to iOS
         run: |
-          #brew install llvm
-          #export #PATH=/opt/homebrew/opt/llvm/bin:$PATH
-          # export #LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
-          export #CPPFLAGS="-I/opt/homebrew/opt/llvm/include" 
-          export CC=/Applications/Xcode_26.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
-          export CFLAGS="-O2 -unwindlib=none -Wno-macro-redefined -isysroot /Applications/Xcode_26.0.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk -arch arm64 -miphoneos-version-min=10.0"
-          xcrun --sdk iphoneos --show-sdk-path
-          ls -l /Applications
-          make TARGET=ARMV8 NUM_THREADS=32 HOSTCC=clang NOFORTRAN=1 CROSS=1
+          CC="$(xcrun --sdk iphoneos --find clang)"
+          SDKROOT="$(xcrun --sdk iphoneos --show-sdk-path)"
+          echo "CC=${CC}"
+          echo "SDKROOT=${SDKROOT}"
+          make TARGET=ARMV8 DYNAMIC_ARCH=1 NUM_THREADS=32 HOSTCC=clang NOFORTRAN=1 \
+            CC="${CC}" CFLAGS="-O2 -Wno-macro-redefined -isysroot ${SDKROOT} -arch arm64 -miphoneos-version-min=10.0"
 
   xbuild-ios32:
     if: "github.repository == 'OpenMathLib/OpenBLAS'"
@@ -296,4 +293,3 @@ jobs:
           export AR=/opt/homebrew/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
           export RANLIB=/opt/homebrew/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ranlib
           make TARGET=ARMV7 ARM_SOFTFP_ABI=1 NUM_THREADS=32 HOSTCC=clang NOFORTRAN=1
-

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 TOPDIR	= .
 include ./Makefile.system
 LNCMD = ln -fs
+OSNAME_DISPLAY ?= $(OSNAME)
 ifeq ($(FIXED_LIBNAME), 1)
 LNCMD = true
 endif
@@ -58,7 +59,7 @@ all :: tests
 	@echo
 	@echo " OpenBLAS build complete. ($(LIB_COMPONENTS))"
 	@echo
-	@echo "  OS               ... $(OSNAME)             "
+	@echo "  OS               ... $(OSNAME_DISPLAY)             "
 	@echo "  Architecture     ... $(ARCH)               "
 ifndef BINARY64
 	@echo "  BINARY           ... 32bit                 "

--- a/c_check
+++ b/c_check
@@ -23,7 +23,7 @@ config="$2"
 compiler_name="$3"
 shift 3
 flags="$*"
-is_ios=false
+darwin_os=""
 
 # First, we need to know the target OS and compiler name
 {
@@ -70,7 +70,7 @@ case "$data" in *OS_FREEBSD*) os=FreeBSD ;; esac
 case "$data" in *OS_NETBSD*) os=NetBSD ;; esac
 case "$data" in *OS_OPENBSD*) os=OpenBSD ;; esac
 case "$data" in *OS_DRAGONFLY*) os=DragonFly ;; esac
-case "$data" in *OS_DARWIN*) os=Darwin ;; esac
+case "$data" in *OS_DARWIN*) os=Darwin; darwin_os=macOS ;; esac
 case "$data" in *OS_SUNOS*) os=SunOS ;; esac
 case "$data" in *OS_AIX*) os=AIX ;; esac
 case "$data" in *OS_OSF*) os=osf ;; esac
@@ -79,7 +79,7 @@ case "$data" in *OS_CYGWIN_NT*) os=CYGWIN_NT ;; esac
 case "$data" in *OS_INTERIX*) os=Interix ;; esac
 case "$data" in *OS_ANDROID*) os=Android ;; esac
 case "$data" in *OS_HAIKU*) os=Haiku ;; esac
-case "$data" in *OS_IOS*) is_ios=true ;; esac
+case "$data" in *OS_IOS*) darwin_os=iOS ;; esac
 
 case "$data" in
     *ARCH_X86_64*) architecture=x86_64 ;;
@@ -404,7 +404,7 @@ fi
 data=`$compiler_name $flags -S ctest1.c && grep globl ctest1.s | head -n 1 && rm -f ctest1.s`
 
 need_fu=''
-if echo "$data" | grep 'globl[[:space:]][_\.]'; then
+if echo "$data" | grep -q 'globl[[:space:]][_\.]'; then
     need_fu="${data##*globl[[:space:]]}"
     need_fu="${need_fu%%[!_\.]*}"
 fi
@@ -421,7 +421,7 @@ fi
 [ "$os" = "Android" ] && [ "$hostos" = "Linux" ] && [ -n "$TERMUX_APP_PID" ] \
     && cross=0
 
-[ "$is_ios" = true ] && cross=1
+[ "$darwin_os" = iOS ] && cross=1
 
 [ "$USE_OPENMP" != 1 ] && openmp=''
 
@@ -489,11 +489,11 @@ done
 :> "$makefile" || exit 1
 :> "$config" || exit 1
 
-
 # print $data, "\n";
 
 {
     printf "OSNAME=%s\n" "$os"
+    [ -n "$darwin_os" ] && printf "OSNAME_DISPLAY=%s\n" "$darwin_os"
     printf "ARCH=%s\n" "$architecture"
     printf "C_COMPILER=%s\n" "$compiler"
     [ $binformat != 'bin32' ] && printf "BINARY32=\n"

--- a/c_check.pl
+++ b/c_check.pl
@@ -56,6 +56,7 @@ if ($@){
 }
 
 $compiler = "";
+$darwin_os = "";
 $compiler = LSB       if ($data =~ /COMPILER_LSB/);
 $compiler = CLANG     if ($data =~ /COMPILER_CLANG/);
 $compiler = PGI       if ($data =~ /COMPILER_PGI/);
@@ -73,7 +74,13 @@ $os = FreeBSD         if ($data =~ /OS_FREEBSD/);
 $os = NetBSD          if ($data =~ /OS_NETBSD/);
 $os = OpenBSD         if ($data =~ /OS_OPENBSD/);
 $os = DragonFly       if ($data =~ /OS_DRAGONFLY/);
-$os = Darwin          if ($data =~ /OS_DARWIN/);
+if ($data =~ /OS_DARWIN/) {
+    $os = Darwin;
+    $darwin_os = "macOS";
+}
+if ($data =~ /OS_IOS/) {
+    $darwin_os = "iOS";
+}
 $os = SunOS           if ($data =~ /OS_SUNOS/);
 $os = AIX             if ($data =~ /OS_AIX/);
 $os = osf             if ($data =~ /OS_OSF/);
@@ -391,6 +398,7 @@ if ($architecture ne $hostarch) {
 
 $cross = 1 if ($os ne $hostos);
 $cross = 0 if (($os eq "Android") && ($hostos eq "Linux") && ($ENV{TERMUX_APP_PID} != ""));
+$cross = 1 if $darwin_os eq "iOS";
 
 $openmp = "" if $ENV{USE_OPENMP} != 1;
 
@@ -454,6 +462,7 @@ open(CONFFILE, "> $config"  ) || die "Can't create $config";
 # print $data, "\n";
 
 print MAKEFILE "OSNAME=$os\n";
+print MAKEFILE "OSNAME_DISPLAY=$darwin_os\n" if $darwin_os ne "";
 print MAKEFILE "ARCH=$architecture\n";
 print MAKEFILE "C_COMPILER=$compiler\n";
 print MAKEFILE "BINARY32=\n" if $binformat ne bin32;

--- a/ctest.c
+++ b/ctest.c
@@ -182,6 +182,6 @@ ARCH_WASM
 OS_WINDOWS
 #endif
 
-#if defined(TARGET_OS_IPHONE)
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 OS_IOS
 #endif

--- a/docs/install.md
+++ b/docs/install.md
@@ -710,7 +710,7 @@ message about a missing declaration or missing header file complex.h)
 
 ### iPhone/iOS
 
-As none of the current developers uses iOS, the following instructions are what
+As few of the current developers use iOS, the following instructions are what
 was found to work in our Azure CI setup, but as far as we know this builds a
 fully working OpenBLAS for this platform.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -716,14 +716,13 @@ fully working OpenBLAS for this platform.
 
 Go to the directory where you unpacked OpenBLAS,and enter the following commands:
 ```bash
-CC="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
-
+CC="$(xcrun --sdk iphoneos --find clang)"
 SDKROOT="$(xcrun --sdk iphoneos --show-sdk-path)"
-CFLAGS="-O2 -Wno-macro-redefined -isysroot $SDKROOT -arch arm64 -miphoneos-version-min=10.0"
 
-make TARGET=ARMV8 DYNAMIC_ARCH=1 NUM_THREADS=32 HOSTCC=clang NOFORTRAN=1
+make TARGET=ARMV8 DYNAMIC_ARCH=1 NUM_THREADS=32 HOSTCC=clang NOFORTRAN=1 \
+  CC="${CC}" CFLAGS="-O2 -Wno-macro-redefined -isysroot ${SDKROOT} -arch arm64 -miphoneos-version-min=10.0"
 ```
-Adjust `MIN_IOS_VERSION` as necessary for your installation. E.g., change the version number
+Adjust `-miphoneos-version-min` as necessary for your installation. E.g., change the version number
 to the minimum iOS version you want to target and execute this file to build the library.
 
 ### HarmonyOS


### PR DESCRIPTION
This PR fixes Apple platform detection and iOS cross-build instructions.

The main issue is that Apple clang defines `TARGET_OS_IPHONE` on macOS as well,
but with value `0`. The previous detection only checked whether the macro was
defined, so macOS builds could be identified as iOS. This PR checks the macro
value, adds a separate display name for Darwin targets, and updates the iOS CI
and documentation build commands so that iPhoneOS compiler flags are actually
passed to `make`.

## Changes

### `ctest.c`

- Change iOS detection from `defined(TARGET_OS_IPHONE)` to
  `defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE`.
- This avoids treating normal macOS builds as iOS, because Apple headers define
  `TARGET_OS_IPHONE` as `0` for macOS targets.

### `c_check`

- Replace the boolean `is_ios` state with `darwin_os`, which records the Darwin
  target kind as `macOS` or `iOS`.
- Keep the internal build OS as `Darwin`, while writing `OSNAME_DISPLAY` for
  user-facing output.
- Set `CROSS=1` when the detected Darwin target kind is `iOS`.
- Use `grep -q` when checking the generated assembly symbol prefix, avoiding
  accidental diagnostic output from the detection command.

### `c_check.pl`

- Mirror the shell `c_check` behavior in the Perl fallback script.
- Track `darwin_os` separately from `OSNAME`.
- Emit `OSNAME_DISPLAY` only for Darwin targets.
- Set cross-compilation mode for iOS targets.

### `Makefile`

- Add `OSNAME_DISPLAY ?= $(OSNAME)`.
- Print `OSNAME_DISPLAY` in the final build summary instead of the internal
  `OSNAME`.
- This keeps existing build logic based on `Darwin`, while showing users
  `macOS` or `iOS` in the summary.

### `.github/workflows/apple_m.yml`

- Update the iOS cross-build step to query the iPhoneOS clang and SDK path with
  `xcrun`.
- Pass `CC` and `CFLAGS` directly to `make`, instead of setting shell variables
  that `make` would not necessarily receive.
- Print the resolved `CC` and `SDKROOT` values in CI logs for easier debugging.
- Restore `DYNAMIC_ARCH=1` in the iOS CI build command.

### `docs/install.md`

- Update the iOS build instructions to match the CI command.
- Use `xcrun --sdk iphoneos --find clang` instead of a hard-coded Xcode path.
- Pass `CC` and `CFLAGS` directly to `make`.
- Fix the follow-up note to refer to the actual
  `-miphoneos-version-min` flag instead of `MIN_IOS_VERSION`.