### PR TITLE
Restore WoA compatibility fix in dynamic_arm64.c

### DIFF
--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -38,7 +38,13 @@
 /*********************************************************************/
 
 #include "common.h"
+
+#ifndef _MSC_VER
 #include <strings.h>
+#else
+#define strncasecmp _strnicmp
+#endif
+
 #if (defined OS_LINUX || defined OS_ANDROID)
 #include <asm/hwcap.h>
 #include <sys/auxv.h>


### PR DESCRIPTION
inadvertently dropped in #5719 when reworking VORTEX support, noticed in #5713