### PR TITLE
Makefile.system: when Clang is used, check if gfortran is used

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -422,6 +422,9 @@ endif
 ifeq ($(C_COMPILER), CLANG)
 CLANGVERSIONGTEQ9 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 9)
 CLANGVERSIONGTEQ12 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 12)
+ifeq ($(F_COMPILER), GFORTRAN)
+GCCVERSIONGT4 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \> 4)
+endif
 endif
 
 #


### PR DESCRIPTION
At least on power, GCCVERSIONGT4 is checked for when gfortran is used, like at Makefile.power:59