### PR TITLE
Makefile.power: allow using power10 instructions

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -111,7 +111,7 @@ endif
 endif
 
 ifeq ($(C_COMPILER), CLANG)
-CCOMMON_OPT += -fno-integrated-as
+CCOMMON_OPT += -fno-integrated-as -Wa,-mpower10
 endif
 # workaround for C->FORTRAN ABI violation in LAPACKE
 ifeq ($(F_COMPILER), GFORTRAN)


### PR DESCRIPTION
OpenBLAS uses various power9 and power10 instructions and they fail to build with errors like in https://github.com/OpenMathLib/OpenBLAS/issues/4793. Just allow the latest ISA, it will generate the same code, but actually allow the binaries to be assembled.