### PR TITLE
Use -mpwr10 instead of -mpower10 to support AIX assembler

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -111,7 +111,7 @@ endif
 endif
 
 ifeq ($(C_COMPILER), CLANG)
-CCOMMON_OPT += -fno-integrated-as -Wa,-mpower10
+CCOMMON_OPT += -fno-integrated-as -Wa,-mpwr10
 endif
 # workaround for C->FORTRAN ABI violation in LAPACKE
 ifeq ($(F_COMPILER), GFORTRAN)


### PR DESCRIPTION
#5802 broke OpenBLAS build on AIX with the below error,
```
Assembler:
line 1: 1252-162 Invalid -m flag assembly mode operand: POWER10.
	Valid values are:COM PWR PWR2 PPC 601 603 604 PPC64 620 A35 PWR4 PWR5 PWR5X 970 PPC970 PWR6 PWR6E PWR7 PWR8 PWR9 PWR10 ANY
/tmp/scal-bfa82c.s: line 14: 1252-149 Instruction stdu is not implemented in the current assembly mode PPC64.
/tmp/scal-bfa82c.s: line 15: 1252-149 Instruction std is not implemented in the current assembly mode PPC64.
```
AIX assembler recognise only "-mpwrX" variant instead of "-mpowerX". GNU binutils assembler recognises both. So let's have "-mpwr10" instead of "-mpower10".