### PR TITLE
Fix incorrect leading dimension check for SME SGEMM direct kernel path

### DIFF
--- a/interface/gemm.c
+++ b/interface/gemm.c
@@ -562,12 +562,12 @@ if (strcmp(gotoblas_corename(), "armv9sme") == 0
 )
 // if (support_sme1())
 #endif
-  if (order == CblasRowMajor && m==lda && n ==ldb && k==ldc && beta == 0 && alpha == 1.0 && TransA == CblasNoTrans && TransB == CblasNoTrans&& SGEMM_DIRECT_PERFORMANT(m,n,k)) {
+  if (order == CblasRowMajor && k==lda && n==ldb && n==ldc && beta == 0 && alpha == 1.0 && TransA == CblasNoTrans && TransB == CblasNoTrans && SGEMM_DIRECT_PERFORMANT(m,n,k)) {
         SGEMM_DIRECT(m, n, k, a, lda, b, ldb, c, ldc);
         return;
   }
 else
- if (order == CblasRowMajor && m==lda && n==ldb && k==ldc && TransA == CblasNoTrans && TransB == CblasNoTrans&& SGEMM_DIRECT_PERFORMANT(m,n,k)) {
+ if (order == CblasRowMajor && k==lda && n==ldb && n==ldc && TransA == CblasNoTrans && TransB == CblasNoTrans && SGEMM_DIRECT_PERFORMANT(m,n,k)) {
         SGEMM_DIRECT_ALPHA_BETA(m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
         return;
   }


### PR DESCRIPTION
For row-major matrices, the tight-packing condition should be k==lda (A is m×k), n==ldb (B is k×n), and n==ldc (C is m×n). The old check used m==lda and k==ldc, which prevented the SME/direct kernel from being invoked except when m==k==n (square matrices).

Fixes https://github.com/OpenMathLib/OpenBLAS/issues/5794