### PR TITLE
Fix TRSM on Barcelona target (and possibly others)

### DIFF
--- a/interface/trsm.c
+++ b/interface/trsm.c
@@ -381,8 +381,12 @@ if (strcmp(gotoblas_corename(), "armv9sme") == 0
 #endif
 #endif
 
+
+
+//end of the ifndef CBLAS ... else ... section	
 #endif
 
+  if ((args.m == 0) || (args.n == 0)) return;
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();


### PR DESCRIPTION
Restores the quick return I had mistakenly removed as part of #5767 - what I mistook as redundant is actually the guard in common code, while the copy I had put above it was only guarding kernel calls from CBLAS.
fixes #5810 as suggested there