### PR TITLE
Fix OpenMP reentrancy issues in LLVM compilations with gmake on ARM64

### DIFF
--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -310,12 +310,10 @@ endif
 
 ifeq ($(CORE), VORTEXM4)
 ifneq ($(C_COMPILER), GCC)
-ifeq ($(APPLECLANG),1)
 CCOMMON_OPT += -march=armv8.4-a+sme
-else
-CCOMMON_OPT += -march=armv8.4-a+sme
-override LDFLAGS += -lclang_rt_builtins-aarch64
-endif
+#ifneq ($(APPLECLANG),1)
+#override LDFLAGS += -lclang_rt_builtins-aarch64
+#endif
 else
 CCOMMON_OPT += -march=armv8.4-a
 endif

--- a/c_check
+++ b/c_check
@@ -342,8 +342,8 @@ no_sme=0
 is_appleclang=0
 if [ "$architecture" = "arm64" ]; then
     if [ "$compiler" = "CLANG" ]; then
-        data=`$compiler_name --version`
-	case "$data" in Apple*)
+        vdata=`$compiler_name --version`
+	case "$vdata" in Apple*)
 	is_appleclang=1
 	esac
     fi

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -38,12 +38,10 @@ ifeq ($(TARGET_CORE), VORTEXM4)
   ifeq ($(C_COMPILER), GCC)
     override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE) -UHAVE_SME -march=armv8.4-a
   else
-    ifeq ($(APPLECLANG),1)
-      override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE) -march=armv8.4-a+sme
-    else
-      override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE) -march=armv8.4-a+sme
-	  override LDFLAGS += -lclang_rt_builtins-aarch64
-    endif
+    override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE) -march=armv8.4-a+sme
+#   ifneq ($(APPLECLANG),1)
+#     override LDFLAGS += -lclang_rt_builtins-aarch64
+#   endif
     ifdef OS_WINDOWS
       ifeq ($(C_COMPILER), CLANG)
         override CFLAGS += --aarch64-stack-hazard-size=0


### PR DESCRIPTION
fixes #5825 - problem was introduced by my #5423 inadvertently invalidating the C11 Atomics capability check in the build system, leading to less reliable locking being used to protect against concurrent calls from OpenMP code.