### PR TITLE
Add support for QEMU's virtual AMD cpu to avoid misdetection as  Opteron

### DIFF
--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -838,7 +838,6 @@ static gotoblas_t *get_coretype(void){
 			 return &gotoblas_ZEN;
           else
             return &gotoblas_BARCELONA;
-		  }
 		}
 	    if (ecx & (1 <<  0)) return &gotoblas_OPTERON_SSE3;
 	else return &gotoblas_OPTERON;

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -829,7 +829,18 @@ static gotoblas_t *get_coretype(void){
       }
     if (family == 0xf){
       if ((exfamily == 0) || (exfamily == 2)) {
-	if (ecx & (1 <<  0)) return &gotoblas_OPTERON_SSE3;
+		if (exmodel == 6 && model == 11) { /*QEMU virtual cpu*/
+	      if (support_avx512_bf16())
+             return &gotoblas_COOPERLAKE;
+          if (support_avx512())
+	         return &gotoblas_SKYLAKEX;
+          if (support_avx2())
+			 return &gotoblas_ZEN;
+          else
+            return &gotoblas_BARCELONA;
+		  }
+		}
+	    if (ecx & (1 <<  0)) return &gotoblas_OPTERON_SSE3;
 	else return &gotoblas_OPTERON;
       }  else if (exfamily == 5 || exfamily == 7) {
 	return &gotoblas_BOBCAT;


### PR DESCRIPTION
.... leading to SIGILL as no modern system supports Opteron's 3DNOW extensions anymore
fixes #5831