### PR TITLE
bench.h: fix getsec() double time conversion on Apple Silicon

### DIFF
--- a/benchmark/bench.h
+++ b/benchmark/bench.h
@@ -95,7 +95,6 @@ static void *aligned_alloc_cacheline(size_t n)
 #if defined(__WIN32__) || defined(__WIN64__) || !defined(_POSIX_TIMERS)
   struct timeval start, stop;
 #elif defined(__APPLE__)
- mach_timebase_info_data_t info;
  uint64_t start = 0, stop = 0;
 #else
   struct timespec start = { 0, 0 }, stop = { 0, 0 };
@@ -106,8 +105,7 @@ double getsec()
 #if defined(__WIN32__) || defined(__WIN64__) || !defined(_POSIX_TIMERS)
     return (double)(stop.tv_sec - start.tv_sec) + (double)((stop.tv_usec - start.tv_usec)) * 1.e-6;
 #elif defined(__APPLE__)
-    mach_timebase_info(&info);
-    return (double)(((stop - start) * info.numer)/info.denom) * 1.e-9;
+    return (double)(stop - start) * 1.e-9;
 #else
     return (double)(stop.tv_sec - start.tv_sec) + (double)((stop.tv_nsec - start.tv_nsec)) * 1.e-9;
 #endif


### PR DESCRIPTION
On Apple Silicon, begin()/end() use clock_gettime_nsec_np(CLOCK_UPTIME_RAW), which already returns nanoseconds. getsec() then also multiplies by mach_timebase_info numer/denom — a conversion only valid for raw mach_absolute_time() ticks. On M-series numer/denom = 125/3, so every benchmark reports time ~41.67x too high (MFlops ~41.67x too low).

Repro (M-series): sleep 0.5s between begin()/end(), getsec() returns ~20.9s.

Drop the timebase scaling in the __APPLE__ branch.