### PR TITLE
fix data races in blas_server and level3_thread

### DIFF
--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -200,7 +200,7 @@ jobs:
           - msystem: MINGW32
             idx: int32
             target-prefix: mingw-w64-i686
-            fc-pkg: 
+            fc-pkg:
           - msystem: CLANG64
             idx: int32
             target-prefix: mingw-w64-clang-x86_64
@@ -460,13 +460,12 @@ jobs:
         run: |
           cd build
           if [ "${{ matrix.backend }}" = "tsan" ]; then
-            export OPENBLAS_NUM_THREADS=2
             export LLVM_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
             export TSAN_OPTIONS=halt_on_error=1:exitcode=66:second_deadlock_stack=1
           else
-            export OPENBLAS_NUM_THREADS=8
             export OMP_NUM_THREADS=16
           fi
+          export OPENBLAS_NUM_THREADS=8
           ctest -R 'dgemm_thread_safety|dgemm_thread_safety_mixed|dgemv_thread_safety' --output-on-failure
 
 
@@ -687,7 +686,7 @@ jobs:
       - name: Build OpenBLAS
         run: |
           make -j${nproc} TARGET=NEOVERSEN1 USE_OPENMP=1
-  
+
   neoverse_n1_ilp64_build:
     if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: ubuntu-24.04-arm

--- a/driver/level3/level3_thread.c
+++ b/driver/level3/level3_thread.c
@@ -98,7 +98,11 @@
 #endif
 
 typedef struct {
+#ifdef HAVE_C11
+  _Atomic
+#else
   volatile
+#endif
    BLASLONG working[MAX_CPU_NUMBER][CACHE_LINE_SIZE * DIVIDE_RATE_MAX];
 } job_t;
 

--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -631,7 +631,13 @@ int blas_thread_init(void){
      exec_blas       ... returns after jobs are finished.
 */
 
+#if   defined(USE_PTHREAD_LOCK)
+static pthread_mutex_t   exec_queue_lock = PTHREAD_MUTEX_INITIALIZER;
+#elif defined(USE_PTHREAD_SPINLOCK)
+static pthread_spinlock_t exec_queue_lock = 0;
+#else
 static BLASULONG exec_queue_lock = 0;
+#endif
 
 int exec_blas_async(BLASLONG pos, blas_queue_t *queue){
 
@@ -652,7 +658,7 @@ int exec_blas_async(BLASLONG pos, blas_queue_t *queue){
   fprintf(STDERR, "Exec_blas_async is called. Position = %d\n", pos);
 #endif
 
-  blas_lock(&exec_queue_lock);
+  LOCK_COMMAND(&exec_queue_lock);
 
     while (queue) {
       queue -> position  = pos;
@@ -717,7 +723,7 @@ int exec_blas_async(BLASLONG pos, blas_queue_t *queue){
 
     }
 
-    blas_unlock(&exec_queue_lock);
+    UNLOCK_COMMAND(&exec_queue_lock);
 
 #ifdef SMP_DEBUG
     fprintf(STDERR, "Done(Number of threads = %2ld).\n", exec_count);


### PR DESCRIPTION
This PR fixes the remaining data races from https://github.com/OpenMathLib/OpenBLAS/pull/5838/ where previously it caused data races when the number of threads was higher than 2. With this PR, there are no such data races when running the tests even with 16 threads as I tested on my system.