### PR TITLE
Don't check LDU in LAPACKE_?GESVD_WORK when U is not used (from Reference-LAPACK PR 1284)

### DIFF
--- a/lapack-netlib/LAPACKE/src/lapacke_cgesvd_work.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_cgesvd_work.c
@@ -69,17 +69,19 @@ lapack_int LAPACKE_cgesvd_work( int matrix_layout, char jobu, char jobvt,
             LAPACKE_xerbla( "LAPACKE_cgesvd_work", info );
             return info;
         }
-        if( ldu < ncols_u ) {
-            info = -10;
-            LAPACKE_xerbla( "LAPACKE_cgesvd_work", info );
-            return info;
+	if( LAPACKE_lsame( jobu, 'a' ) || LAPACKE_lsame( jobu, 's' ) ) {
+            if( ldu < ncols_u ) {
+                info = -10;
+                LAPACKE_xerbla( "LAPACKE_cgesvd_work", info );
+                return info;
+	    }
         }
 	if( LAPACKE_lsame( jobvt, 'a' ) || LAPACKE_lsame( jobvt, 's' ) ) {
-	if( ldvt < ncols_vt ) {
-            info = -12;
-            LAPACKE_xerbla( "LAPACKE_cgesvd_work", info );
-            return info;
-        }
+	    if( ldvt < ncols_vt ) {
+                info = -12;
+                LAPACKE_xerbla( "LAPACKE_cgesvd_work", info );
+                return info;
+            }
         }
         /* Query optimal working array(s) size if requested */
         if( lwork == -1 ) {

--- a/lapack-netlib/LAPACKE/src/lapacke_dgesvd_work.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_dgesvd_work.c
@@ -67,17 +67,19 @@ lapack_int LAPACKE_dgesvd_work( int matrix_layout, char jobu, char jobvt,
             LAPACKE_xerbla( "LAPACKE_dgesvd_work", info );
             return info;
         }
-        if( ldu < ncols_u ) {
-            info = -10;
-            LAPACKE_xerbla( "LAPACKE_dgesvd_work", info );
-            return info;
+	if( LAPACKE_lsame( jobu, 'a' ) || LAPACKE_lsame( jobu, 's' ) ) {
+            if( ldu < ncols_u ) {
+                info = -10;
+                LAPACKE_xerbla( "LAPACKE_dgesvd_work", info );
+                return info;
+	    }
         }
 	if( LAPACKE_lsame( jobvt, 'a' ) || LAPACKE_lsame( jobvt, 's' ) ) {
-        if( ldvt < ncols_vt ) {
-            info = -12;
-            LAPACKE_xerbla( "LAPACKE_dgesvd_work", info );
-            return info;
-        }
+            if( ldvt < ncols_vt ) {
+                info = -12;
+                LAPACKE_xerbla( "LAPACKE_dgesvd_work", info );
+                return info;
+            }
         }
         /* Query optimal working array(s) size if requested */
         if( lwork == -1 ) {

--- a/lapack-netlib/LAPACKE/src/lapacke_sgesvd_work.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_sgesvd_work.c
@@ -67,17 +67,19 @@ lapack_int LAPACKE_sgesvd_work( int matrix_layout, char jobu, char jobvt,
             LAPACKE_xerbla( "LAPACKE_sgesvd_work", info );
             return info;
         }
-        if( ldu < ncols_u ) {
-            info = -10;
-            LAPACKE_xerbla( "LAPACKE_sgesvd_work", info );
-            return info;
+        if( LAPACKE_lsame( jobu, 'a' ) || LAPACKE_lsame( jobu, 's' ) ) {
+            if( ldu < ncols_u ) {
+                info = -10;
+                LAPACKE_xerbla( "LAPACKE_sgesvd_work", info );
+                return info;
+	    }
         }
         if( LAPACKE_lsame( jobvt, 'a' ) || LAPACKE_lsame( jobvt, 's' ) ) {
-	if( ldvt < ncols_vt ) {
-            info = -12;
-            LAPACKE_xerbla( "LAPACKE_sgesvd_work", info );
-            return info;
-        }
+	    if( ldvt < ncols_vt ) {
+                info = -12;
+                LAPACKE_xerbla( "LAPACKE_sgesvd_work", info );
+                return info;
+            }
         }
         /* Query optimal working array(s) size if requested */
         if( lwork == -1 ) {

--- a/lapack-netlib/LAPACKE/src/lapacke_zgesvd_work.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zgesvd_work.c
@@ -69,17 +69,19 @@ lapack_int LAPACKE_zgesvd_work( int matrix_layout, char jobu, char jobvt,
             LAPACKE_xerbla( "LAPACKE_zgesvd_work", info );
             return info;
         }
-        if( ldu < ncols_u ) {
-            info = -10;
-            LAPACKE_xerbla( "LAPACKE_zgesvd_work", info );
-            return info;
+	if( LAPACKE_lsame( jobu, 'a' ) || LAPACKE_lsame( jobu, 's' ) ) {
+            if( ldu < ncols_u ) {
+                info = -10;
+                LAPACKE_xerbla( "LAPACKE_zgesvd_work", info );
+                return info;
+	    }
         }
 	if( LAPACKE_lsame( jobvt, 'a' ) || LAPACKE_lsame( jobvt, 's' ) ) {
-	if( ldvt < ncols_vt ) {
-            info = -12;
-            LAPACKE_xerbla( "LAPACKE_zgesvd_work", info );
-            return info;
-        }
+	    if( ldvt < ncols_vt ) {
+                info = -12;
+                LAPACKE_xerbla( "LAPACKE_zgesvd_work", info );
+                return info;
+	    }
         }
         /* Query optimal working array(s) size if requested */
         if( lwork == -1 ) {


### PR DESCRIPTION
this expands my previous #5052 to cover both LDU and LDVT