### PR TITLE
mkdocs: set repo_name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: OpenBLAS
 site_url: https://openblas.net/docs/
+repo_name: "OpenMathLib/OpenBLAS"
 repo_url: https://github.com/OpenMathLib/OpenBLAS
 copyright: Copyright &copy; 2012- OpenBLAS contributors
 


### PR DESCRIPTION
That way the path to the GitHub repo is displayed instead of just the generic text "GitHub"