### PR TITLE
Fix/laed3 sqrt nan guard

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -278,3 +278,4 @@ In chronological order:
 
 * Nathan Sircombe <nathan.sircombe@arm.com>
   * [2026-04-16] Add CPU ID for Neoverse V3
+hheei <hheei@users.noreply.github.com>

--- a/lapack/laed3/laed3_parallel.c
+++ b/lapack/laed3/laed3_parallel.c
@@ -203,7 +203,7 @@ blasint CNAME(blasint *k, blasint *n, blasint *n1, FLOAT *d,
       exec_blas(num_cpu, queue);
     }
     for (i = 0; i < kval; i++) {
-      temp = sqrt(-w[i]);
+      temp = sqrt(fmax(-w[i], 0.0));
       w[i] = copysign(temp, s[i]);
     }
 

--- a/lapack/laed3/laed3_single.c
+++ b/lapack/laed3/laed3_single.c
@@ -123,7 +123,7 @@ blasint CNAME(blasint *k, blasint *n, blasint *n1, FLOAT *d,
       }
     }
     for (i = 0; i < kval; i++) {
-      temp = sqrt(-w[i]);
+      temp = sqrt(fmax(-w[i], 0.0));
       w[i] = copysign(temp, s[i]);
     }
 

--- a/test/test_laed3_nan.c
+++ b/test/test_laed3_nan.c
@@ -1,0 +1,37 @@
+/*
+ * Test for NaN in DSYEVD eigenvectors due to numerical instability
+ * in DLAED3 (divide-and-conquer merge) when eigenvalues are nearly degenerate.
+ *
+ * Build: gcc -o test_laed3_nan test_laed3_nan.c -lopenblas -lm
+ * Run:   ./test_laed3_nan
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+extern void dsyevd_(char *jobz, char *uplo, int *n, double *a, int *lda,
+                    double *w, double *work, int *lwork, int *iwork, int *liwork,
+                    int *info);
+
+int main(void) {
+    int n = 8, lda = 8, lwork = 1 + 6*8 + 2*64, liwork = 3 + 5*8, info;
+    double *a = malloc(n*lda*sizeof(double));
+    double *w = malloc(n*sizeof(double));
+    double *work = malloc(lwork*sizeof(double));
+    int *iwork = malloc(liwork*sizeof(int));
+    double eps = 1e-8, alpha = 10.0;
+    double v[8] = {1.0, 1.0+eps, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    for (int i = 0; i < n; i++)
+        for (int j = 0; j < n; j++)
+            a[i+j*lda] = (i==j ? 1.0 : 0.0) + alpha*v[i]*v[j];
+    char jobz = 'V', uplo = 'U';
+    dsyevd_(&jobz, &uplo, &n, a, &lda, w, work, &lwork, iwork, &liwork, &info);
+    if (info) { printf("DSYEVD info=%d\n",info); return 1; }
+    int nan=0;
+    for (int i=0; i<n; i++) if (isnan(w[i])) nan++;
+    for (int i=0; i<n*n; i++) if (isnan(a[i])) nan++;
+    if (nan) { printf("FAIL: %d NaN(s)\n", nan); return 1; }
+    printf("PASS: No NaN\n");
+    free(a); free(w); free(work); free(iwork);
+    return 0;
+}


### PR DESCRIPTION
## Summary

Guard the `sqrt(-w[i])` call in `DLAED3` (divide-and-conquer merge used by `DSYEVD`/`DSTEDC`) against spuriously positive `w[i]` preventing NaN eigenvector output.

## Problem

When eigenvalues are nearly degenerate, `DLAED3` multiplies weights:
```
w[i] *= q(j,i) / (dlamda[i] - dlamda[j])
```

The denominator can approach zero, causing overflow. With `-march=znver1 -O3`, FMA instructions accumulate rounding differently than netlib Fortran, occasionally pushing `w[i]` slightly above zero. The subsequent `sqrt(-w[i])` produces **NaN**, which propagates through all eigenvectors.

This has been observed in production: ABACUS 3.11.0 DFT calculations on 2-node MPI runs (Hygon C86 7185 / Zen 1, GCC 12.5, OpenBLAS 0.3.32) where the ScaLAPACK block-cyclic distribution creates eigenvalue clusters that trigger this edge case.

## Fix

Change `sqrt(-w[i])` to `sqrt(fmax(-w[i], 0.0))` in both files:

| File | Change |
|------|--------|
| `lapack/laed3/laed3_single.c` | line ~121 |
| `lapack/laed3/laed3_parallel.c` | line ~197 |

`fmax` is a standard C99 intrinsic (maps to `vmaxsd` on x86_64). When `w[i]` is spuriously positive it returns `0.0` instead of `NaN`. Correct inputs are unaffected.

## Test

`test/test_laed3_nan.c` constructs a rank-1 perturbed identity matrix that produces near-degenerate eigenvalues, calls `DSYEVD`, and verifies no NaN appears.

Build: `gcc -o test_laed3_nan test_laed3_nan.c -lopenblas -lm`

## Verification

Before (0.3.32): NaN eigenvectors on 2-node MPI (ABACUS+ELPA, Hygon C86)
After (patched): clean eigenvectors verified via 8-stage ELPA internal probes