### PR TITLE
ARM64 SME: fix zero-scalar handling and clean up direct kernels

### DIFF
--- a/kernel/arm64/sgemm_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/sgemm_direct_alpha_beta_arm64_sme1.c
@@ -64,27 +64,30 @@ kernel_2x2(const float *A, const float *B, float *C, size_t shared_dim,
 #define pg_c_1 pg_b_1
 
   svzero_za();
-  svfloat32_t beta_vec = svdup_f32(beta);
+  // beta == 0 must not read C; ZA is already initialized to zero.
+  if (beta != 0.0f) {
+    svfloat32_t beta_vec = svdup_f32(beta);
     // Load C to ZA
-  for (size_t i = 0; i < MIN(svl, block_rows); i++) {
-	svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
-	row_c_0 = svmul_x(pg, beta_vec, row_c_0);
-    svwrite_hor_za32_f32_m(/*tile*/0, /*slice*/i, pg_c_0, row_c_0);
-    
-	svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
-	row_c_1 = svmul_x(pg, beta_vec, row_c_1);
-    svwrite_hor_za32_f32_m(/*tile*/1, /*slice*/i, pg_c_1, row_c_1);
-  }
-  for (size_t i = svl; i < block_rows; i++) {
-    svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
-	row_c_0 = svmul_x(pg, beta_vec, row_c_0);
-	svwrite_hor_za32_f32_m(/*tile*/2, /*slice*/i, pg_c_0, row_c_0);
+    for (size_t i = 0; i < MIN(svl, block_rows); i++) {
+      svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
+      row_c_0 = svmul_x(pg, beta_vec, row_c_0);
+      svwrite_hor_za32_f32_m(/*tile*/0, /*slice*/i, pg_c_0, row_c_0);
 
-    svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
-	row_c_1 = svmul_x(pg, beta_vec, row_c_1);
-    svwrite_hor_za32_f32_m(/*tile*/3, /*slice*/i, pg_c_1, row_c_1);
+      svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
+      row_c_1 = svmul_x(pg, beta_vec, row_c_1);
+      svwrite_hor_za32_f32_m(/*tile*/1, /*slice*/i, pg_c_1, row_c_1);
+    }
+    for (size_t i = svl; i < block_rows; i++) {
+      svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
+      row_c_0 = svmul_x(pg, beta_vec, row_c_0);
+      svwrite_hor_za32_f32_m(/*tile*/2, /*slice*/i, pg_c_0, row_c_0);
+
+      svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
+      row_c_1 = svmul_x(pg, beta_vec, row_c_1);
+      svwrite_hor_za32_f32_m(/*tile*/3, /*slice*/i, pg_c_1, row_c_1);
+    }
   }
-  
+
   svfloat32_t alpha_vec = svdup_f32(alpha);
   // Iterate through shared dimension (K)
   for (size_t k = 0; k < shared_dim; k++) {
@@ -168,7 +171,13 @@ void SME1_KERNEL2X2(uint64_t m, uint64_t k, uint64_t n, const float* alpha,\
 void CNAME (BLASLONG M, BLASLONG N, BLASLONG K, float alpha, float * __restrict A,\
             BLASLONG strideA, float * __restrict B, BLASLONG strideB ,\
             float beta, float * __restrict R, BLASLONG strideR){
-                
+        if (alpha == 0.0f || K == 0) {
+                if (beta == 1.0f)
+                        return;
+                SME1_KERNEL2X2(M, 0, N, &alpha, A, B, &beta, R);
+                return;
+        }
+
         uint64_t m_mod, vl_elms;
         
         vl_elms = sve_cntw();

--- a/kernel/arm64/sgemm_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/sgemm_direct_alpha_beta_arm64_sme1.c
@@ -6,7 +6,6 @@
 #include "common.h"
 #include <stdlib.h>
 #include <inttypes.h>
-#include <math.h>
 
 #if defined(DYNAMIC_ARCH)
 #define COMBINE(a,b) a ## b
@@ -182,7 +181,7 @@ void CNAME (BLASLONG M, BLASLONG N, BLASLONG K, float alpha, float * __restrict 
         
         vl_elms = sve_cntw();
 
-        m_mod = ceil((double)M/(double)vl_elms) * vl_elms;
+        m_mod = (((uint64_t)M + vl_elms - 1) / vl_elms) * vl_elms;
 
         float *A_mod = (float *) malloc(m_mod*K*sizeof(float));
 	    

--- a/kernel/arm64/sgemm_direct_arm64_sme1.c
+++ b/kernel/arm64/sgemm_direct_arm64_sme1.c
@@ -6,7 +6,6 @@
 #include "common.h"
 #include <stdlib.h>
 #include <inttypes.h>
-#include <math.h>
 #if defined(DYNAMIC_ARCH)
 #define COMBINE(a,b) a ## b
 #define COMBINE2(a,b) COMBINE(a,b)
@@ -50,7 +49,7 @@ void CNAME (BLASLONG M, BLASLONG N, BLASLONG K, float * __restrict A,\
         uint64_t m_mod, vl_elms;
         
         vl_elms = sve_cntw();
-        m_mod = ceil((double)M/(double)vl_elms) * vl_elms;
+        m_mod = (((uint64_t)M + vl_elms - 1) / vl_elms) * vl_elms;
 
         float *A_mod = (float *) malloc(m_mod*K*sizeof(float));
 	    

--- a/kernel/arm64/ssymm_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssymm_direct_alpha_beta_arm64_sme1.c
@@ -45,6 +45,7 @@ static uint64_t sve_cntw() {
 
 #if defined(__ARM_FEATURE_SME) && defined(__ARM_FEATURE_LOCALLY_STREAMING) && defined(__clang__) && __clang_major__ >= 16
 
+#if defined(UPPER)
 __arm_new("za") __arm_locally_streaming
 static void ssymm_direct_sme1_preprocessLU(uint64_t nbr, uint64_t nbc,
                 const float *restrict a, float *restrict a_mod)
@@ -54,7 +55,7 @@ static void ssymm_direct_sme1_preprocessLU(uint64_t nbr, uint64_t nbc,
   const uint64_t svl = svcntw();
   uint64_t row_batch = svl;
 
-  float *restrict pSrc;
+  const float *restrict pSrc;
   float *restrict pDst;
   for (uint64_t row_idx = 0; row_idx < nbr; row_idx += row_batch)
   {
@@ -122,8 +123,10 @@ static void ssymm_direct_sme1_preprocessLU(uint64_t nbr, uint64_t nbc,
     }
   }
 }
+#endif
 
 //
+#if defined(LOWER)
 __arm_new("za") __arm_locally_streaming
 static void ssymm_direct_sme1_preprocessLL(uint64_t nbr, uint64_t nbc,
                 const float *restrict a, float *restrict a_mod)
@@ -132,7 +135,7 @@ static void ssymm_direct_sme1_preprocessLL(uint64_t nbr, uint64_t nbc,
   const uint64_t svl = svcntw();
   uint64_t row_batch = svl;
 
-  float *restrict pSrc;
+  const float *restrict pSrc;
   float *restrict pDst;
   for (uint64_t row_idx = 0; row_idx < nbr; row_idx += row_batch)
   {
@@ -200,11 +203,16 @@ static void ssymm_direct_sme1_preprocessLL(uint64_t nbr, uint64_t nbc,
     }
   }
 }
+#endif
 #else
+#if defined(UPPER)
 static void ssymm_direct_sme1_preprocessLU(uint64_t nbr, uint64_t nbc,
                 const float *restrict a, float *restrict a_mod){}
+#endif
+#if defined(LOWER)
 static void ssymm_direct_sme1_preprocessLL(uint64_t nbr, uint64_t nbc,
                 const float *restrict a, float *restrict a_mod){}
+#endif
 #endif
 
 //

--- a/kernel/arm64/ssymm_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssymm_direct_alpha_beta_arm64_sme1.c
@@ -213,6 +213,13 @@ void CNAME(BLASLONG M, BLASLONG N, float alpha, float *__restrict A,
            BLASLONG strideA, float *__restrict B, BLASLONG strideB,
            float beta, float *__restrict R, BLASLONG strideR)
 {
+  if (alpha == 0.0f) {
+    if (beta == 1.0f)
+      return;
+    SGEMM_DIRECT2X2(M, 0, N, &alpha, A, B, &beta, R);
+    return;
+  }
+
   uint64_t vl_elms = sve_cntw(); // vl_elem = 16
   uint64_t m_mod = ceil((double)M / (double)vl_elms) * vl_elms;
 

--- a/kernel/arm64/ssymm_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssymm_direct_alpha_beta_arm64_sme1.c
@@ -6,7 +6,6 @@
 #include "common.h"
 #include <stdlib.h>
 #include <inttypes.h>
-#include <math.h>
 // #include "sme_abi.h"
 #if defined(HAVE_SME)
 
@@ -221,7 +220,7 @@ void CNAME(BLASLONG M, BLASLONG N, float alpha, float *__restrict A,
   }
 
   uint64_t vl_elms = sve_cntw(); // vl_elem = 16
-  uint64_t m_mod = ceil((double)M / (double)vl_elms) * vl_elms;
+  uint64_t m_mod = (((uint64_t)M + vl_elms - 1) / vl_elms) * vl_elms;
 
   /* Pre-process the left matrix to make it suitable for
      matrix sum of outer-product calculation

--- a/kernel/arm64/ssyr2k_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssyr2k_direct_alpha_beta_arm64_sme1.c
@@ -29,6 +29,7 @@ extern void SGEMM_PREPROCESS(uint64_t nbr, uint64_t nbc,\
                                   const float * restrict a, float *  a_mod) ;
 
 /* Function Definitions */
+#if !defined(TRANSA)
 static uint64_t sve_cntw() {
     uint64_t cnt;
     asm volatile(
@@ -38,18 +39,21 @@ static uint64_t sve_cntw() {
     );
     return cnt;
 }
+#endif
 
 #if defined(__ARM_FEATURE_SME) && defined(__ARM_FEATURE_LOCALLY_STREAMING) && defined(__clang__) && __clang_major__ >= 16
 // Outer product kernel.
 // Computes a 2SVL x 2SVL block of C, utilizing all four FP32 tiles of ZA.
 __attribute__((always_inline)) inline void
-kernel_2x2(const float *A, float *B_T, const float *B, float *A_T, float *C, size_t shared_dim,
+kernel_2x2(const float *A, const float *B_T, const float *B, const float *A_T, float *C, size_t shared_dim,
            size_t ldc, size_t block_rows, size_t block_cols, float alpha,
            float beta, uint64_t row_idx, uint64_t col_idx)
     __arm_out("za") __arm_streaming {
 
   const uint64_t svl = svcntw();
+#if defined(TRANSA)
   size_t ldb = ldc;
+#endif
   // Predicate set-up
   svbool_t pg = svptrue_b32();
   svbool_t pg_a_0 = svwhilelt_b32_u64(0, block_rows);

--- a/kernel/arm64/ssyr2k_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssyr2k_direct_alpha_beta_arm64_sme1.c
@@ -6,7 +6,6 @@
 #include "common.h"
 #include <stdlib.h>
 #include <inttypes.h>
-#include <math.h>
 
 #if defined(DYNAMIC_ARCH)
 #define COMBINE(a,b) a ## b
@@ -265,7 +264,7 @@ void CNAME (BLASLONG N, BLASLONG K, float alpha, float * __restrict A, \
 
         vl_elms = sve_cntw();
 
-        n_mod = ceil((double)N/(double)vl_elms) * vl_elms;
+        n_mod = (((uint64_t)N + vl_elms - 1) / vl_elms) * vl_elms;
 
         float *A_mod = (float *) malloc(n_mod*K*sizeof(float));
         float *B_mod = (float *) malloc(n_mod*K*sizeof(float));

--- a/kernel/arm64/ssyr2k_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssyr2k_direct_alpha_beta_arm64_sme1.c
@@ -63,26 +63,29 @@ kernel_2x2(const float *A, float *B_T, const float *B, float *A_T, float *C, siz
 #define pg_c_1 pg_b_1
 
   svzero_za();
-  svfloat32_t beta_vec = svdup_f32(beta);
+  // beta == 0 must not read C; ZA is already initialized to zero.
+  if (beta != 0.0f) {
+    svfloat32_t beta_vec = svdup_f32(beta);
 
-  // Load C to ZA
-  for (size_t i = 0; i < MIN(svl, block_rows); i++) {
-    svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
-    row_c_0 = svmul_x(pg, beta_vec, row_c_0);
-    svwrite_hor_za32_f32_m(/*tile*/0, /*slice*/i, pg_c_0, row_c_0);
+    // Load C to ZA
+    for (size_t i = 0; i < MIN(svl, block_rows); i++) {
+      svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
+      row_c_0 = svmul_x(pg, beta_vec, row_c_0);
+      svwrite_hor_za32_f32_m(/*tile*/0, /*slice*/i, pg_c_0, row_c_0);
 
-    svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
-    row_c_1 = svmul_x(pg, beta_vec, row_c_1);
-    svwrite_hor_za32_f32_m(/*tile*/1, /*slice*/i, pg_c_1, row_c_1);
-  }
-  for (size_t i = svl; i < block_rows; i++) {
-    svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
-    row_c_0 = svmul_x(pg, beta_vec, row_c_0);
-    svwrite_hor_za32_f32_m(/*tile*/2, /*slice*/i, pg_c_0, row_c_0);
+      svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
+      row_c_1 = svmul_x(pg, beta_vec, row_c_1);
+      svwrite_hor_za32_f32_m(/*tile*/1, /*slice*/i, pg_c_1, row_c_1);
+    }
+    for (size_t i = svl; i < block_rows; i++) {
+      svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
+      row_c_0 = svmul_x(pg, beta_vec, row_c_0);
+      svwrite_hor_za32_f32_m(/*tile*/2, /*slice*/i, pg_c_0, row_c_0);
 
-    svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
-    row_c_1 = svmul_x(pg, beta_vec, row_c_1);
-    svwrite_hor_za32_f32_m(/*tile*/3, /*slice*/i, pg_c_1, row_c_1);
+      svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
+      row_c_1 = svmul_x(pg, beta_vec, row_c_1);
+      svwrite_hor_za32_f32_m(/*tile*/3, /*slice*/i, pg_c_1, row_c_1);
+    }
   }
 
   svfloat32_t alpha_vec = svdup_f32(alpha);
@@ -250,6 +253,13 @@ void CNAME (BLASLONG N, BLASLONG K, float alpha, float * __restrict A, \
             BLASLONG strideA, float * __restrict B, BLASLONG strideB, \
             float beta, float * __restrict R, BLASLONG strideR)
 {
+        if (alpha == 0.0f || K == 0) {
+                if (beta == 1.0f)
+                        return;
+                ssyr2k_direct_sme1_2VLx2VL(N, 0, &alpha, A, B, &beta, R);
+                return;
+        }
+
 #if !defined(TRANSA)
         uint64_t n_mod, vl_elms;
 

--- a/kernel/arm64/ssyrk_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssyrk_direct_alpha_beta_arm64_sme1.c
@@ -6,7 +6,6 @@
 #include "common.h"
 #include <stdlib.h>
 #include <inttypes.h>
-#include <math.h>
 #if defined(HAVE_SME)
 
 #if defined(DYNAMIC_ARCH)
@@ -233,7 +232,7 @@ void CNAME (BLASLONG N, BLASLONG K, float alpha, float * __restrict A,\
         
         vl_elms = sve_cntw();
 
-        n_mod = ceil((double)N/(double)vl_elms) * vl_elms;
+        n_mod = (((uint64_t)N + vl_elms - 1) / vl_elms) * vl_elms;
 
         float *A_mod = (float *) malloc(n_mod*K*sizeof(float));
 	    

--- a/kernel/arm64/ssyrk_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssyrk_direct_alpha_beta_arm64_sme1.c
@@ -64,28 +64,31 @@ kernel_2x2(const float *A, float *B, float *C, size_t shared_dim,
 #define pg_c_1 pg_b_1
 
   svzero_za();
-  svfloat32_t beta_vec = svdup_f32(beta);
+  // beta == 0 must not read C; ZA is already initialized to zero.
+  if (beta != 0.0f) {
+    svfloat32_t beta_vec = svdup_f32(beta);
 
-  // Load C to ZA
-  for (size_t i = 0; i < MIN(svl, block_rows); i++) {
-    svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
-    row_c_0 = svmul_x(pg, beta_vec, row_c_0);
-    svwrite_hor_za32_f32_m(/*tile*/0, /*slice*/i, pg_c_0, row_c_0);
-    
-    svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
-    row_c_1 = svmul_x(pg, beta_vec, row_c_1);
-    svwrite_hor_za32_f32_m(/*tile*/1, /*slice*/i, pg_c_1, row_c_1);
-  }
-  for (size_t i = svl; i < block_rows; i++) {
-    svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
-    row_c_0 = svmul_x(pg, beta_vec, row_c_0);
-    svwrite_hor_za32_f32_m(/*tile*/2, /*slice*/i - svl, pg_c_0, row_c_0);
+    // Load C to ZA
+    for (size_t i = 0; i < MIN(svl, block_rows); i++) {
+      svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
+      row_c_0 = svmul_x(pg, beta_vec, row_c_0);
+      svwrite_hor_za32_f32_m(/*tile*/0, /*slice*/i, pg_c_0, row_c_0);
 
-    svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
-    row_c_1 = svmul_x(pg, beta_vec, row_c_1);
-    svwrite_hor_za32_f32_m(/*tile*/3, /*slice*/i - svl, pg_c_1, row_c_1);
+      svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
+      row_c_1 = svmul_x(pg, beta_vec, row_c_1);
+      svwrite_hor_za32_f32_m(/*tile*/1, /*slice*/i, pg_c_1, row_c_1);
+    }
+    for (size_t i = svl; i < block_rows; i++) {
+      svfloat32_t row_c_0 = svld1(pg_c_0, &C[i * ldc]);
+      row_c_0 = svmul_x(pg, beta_vec, row_c_0);
+      svwrite_hor_za32_f32_m(/*tile*/2, /*slice*/i - svl, pg_c_0, row_c_0);
+
+      svfloat32_t row_c_1 = svld1(pg_c_1, &C[i * ldc + svl]);
+      row_c_1 = svmul_x(pg, beta_vec, row_c_1);
+      svwrite_hor_za32_f32_m(/*tile*/3, /*slice*/i - svl, pg_c_1, row_c_1);
+    }
   }
-  
+
   svfloat32_t alpha_vec = svdup_f32(alpha);
   // Iterate through shared dimension (K)
   for (size_t k = 0; k < shared_dim; k++) {
@@ -218,7 +221,14 @@ static void ssyrk_direct_sme1_2VLx2VL(uint64_t n, uint64_t k, const float* alpha
 
 void CNAME (BLASLONG N, BLASLONG K, float alpha, float * __restrict A,\
             BLASLONG strideA, float beta, float * __restrict C, BLASLONG strideC){
-#if !defined(TRANSA)          
+        if (alpha == 0.0f || K == 0) {
+                if (beta == 1.0f)
+                        return;
+                ssyrk_direct_sme1_2VLx2VL(N, 0, &alpha, A, &beta, C);
+                return;
+        }
+
+#if !defined(TRANSA)
         uint64_t n_mod, vl_elms;
         
         vl_elms = sve_cntw();

--- a/kernel/arm64/ssyrk_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssyrk_direct_alpha_beta_arm64_sme1.c
@@ -30,6 +30,7 @@ extern void SGEMM_PREPROCESS (uint64_t nbr, uint64_t nbc,\
                                   const float * restrict a, float *  a_mod) ;
 
 /* Function Definitions */
+#if !defined(TRANSA)
 static uint64_t sve_cntw() {
     uint64_t cnt;
     asm volatile(
@@ -39,18 +40,21 @@ static uint64_t sve_cntw() {
     );
     return cnt;
 }
+#endif
 
 #if defined(__ARM_FEATURE_SME) && defined(__ARM_FEATURE_LOCALLY_STREAMING) && defined(__clang__) && __clang_major__ >= 16
 // Outer product kernel.
 // Computes a 2SVL x 2SVL block of C, utilizing all four FP32 tiles of ZA.
 __attribute__((always_inline)) inline void
-kernel_2x2(const float *A, float *B, float *C, size_t shared_dim,
+kernel_2x2(const float *A, const float *B, float *C, size_t shared_dim,
            size_t ldc, size_t block_rows, size_t block_cols, float alpha, 
            float beta, uint64_t row_idx, uint64_t col_idx)
     __arm_out("za") __arm_streaming {
 
   const uint64_t svl = svcntw();
+#if defined(TRANSA)
   size_t ldb = ldc;
+#endif
   // Predicate set-up
   svbool_t pg = svptrue_b32();
   svbool_t pg_a_0 = svwhilelt_b32_u64(0, block_rows);

--- a/kernel/arm64/strmm_direct_arm64_sme1.c
+++ b/kernel/arm64/strmm_direct_arm64_sme1.c
@@ -6,7 +6,6 @@
 #include "common.h"
 #include <stdlib.h>
 #include <inttypes.h>
-#include <math.h>
 //#include "sme_abi.h"
 #if defined(HAVE_SME)
 
@@ -240,7 +239,7 @@ void CNAME (BLASLONG M, BLASLONG N, float alpha, float * __restrict A,\
     
     vl_elms = sve_cntw();
 
-    m_mod = ceil((double)M/(double)vl_elms) * vl_elms;
+    m_mod = (((uint64_t)M + vl_elms - 1) / vl_elms) * vl_elms;
 
     float *A_mod = (float *) malloc(m_mod*M*sizeof(float));
     strmm_direct_sme1_preprocess(M, M, A, A_mod);


### PR DESCRIPTION
### 1. Fix zero alpha/beta semantics

The concrete issues are:

- By BLAS semantics, the input matrix C must not be referenced when `beta == 0`.
- When `alpha == 0` or `K == 0`, only the `beta*C` update is required; A and B should not be read.
- The current SME direct path bypasses the generic Level-3 handling, so NaNs in C or A/B can pollute the output through `0 * NaN`.

### 2. Use integer round-up for padded SME dimensions

```c
ceil((double)M / (double)vl_elms) * vl_elms
```

is replaced with integer arithmetic:

```c
(((uint64_t)M + vl_elms - 1) / vl_elms) * vl_elms
```

### 3. Clean up `const` and unused warnings

- Change the read-only source pointer in the SSYMM preprocess helper to `const float *restrict`.
- For SSYMM, compile only the preprocess helper actually used by the current `UPPER` / `LOWER` object variant.
- Change the read-only `B` parameter in SSYRK `kernel_2x2()` to `const float *`.
- Change the read-only `B_T` and `A_T` parameters in SSYR2K `kernel_2x2()` to `const float *`.
- Compile `sve_cntw()` and `ldb` only in the `TRANSA` / `!TRANSA` variants that actually use them.