### PR TITLE
Update README and CI job matrix documentation

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -4,9 +4,15 @@ on:
   push:
     branches:
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     branches:
       - develop
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/README.md
+++ b/README.md
@@ -2,15 +2,10 @@
 
 [![Join the chat at https://gitter.im/xianyi/OpenBLAS](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/xianyi/OpenBLAS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Cirrus CI: [![Build Status](https://api.cirrus-ci.com/github/xianyi/OpenBLAS.svg?branch=develop)](https://cirrus-ci.com/github/xianyi/OpenBLAS)
+GitHub Actions: [![Build Status](https://github.com/OpenMathLib/OpenBLAS/actions/workflows/dynamic_arch.yml/badge.svg?branch=develop)](https://github.com/OpenMathLib/OpenBLAS/actions/workflows/dynamic_arch.yml?query=branch%3Adevelop)
 
+Azure Pipelines: [![Build Status](https://dev.azure.com/xianyi/OpenBLAS/_apis/build/status/xianyi.OpenBLAS?branchName=develop)](https://dev.azure.com/xianyi/OpenBLAS/_build/latest?definitionId=1&branchName=develop)
 
-
-[![Build Status](https://dev.azure.com/xianyi/OpenBLAS/_apis/build/status/xianyi.OpenBLAS?branchName=develop)](https://dev.azure.com/xianyi/OpenBLAS/_build/latest?definitionId=1&branchName=develop)
-
-OSUOSL POWERCI [![Build Status](https://powerci.osuosl.org/buildStatus/icon?job=OpenBLAS_gh%2Fdevelop)](http://powerci.osuosl.org/job/OpenBLAS_gh/job/develop/)
-
-OSUOSL IBMZ-CI [![Build Status](http://ibmz-ci.osuosl.org/buildStatus/icon?job=OpenBLAS-Z%2Fdevelop)](http://ibmz-ci.osuosl.org/job/OpenBLAS-Z/job/develop/)
 ## Introduction
 
 OpenBLAS is an optimized BLAS (Basic Linear Algebra Subprograms) library based on GotoBLAS2 1.13 BSD version.

--- a/README.md
+++ b/README.md
@@ -287,17 +287,17 @@ Please note that it is not possible to combine support for different architectur
 ### Supported OS
 
 - **GNU/Linux**
-- **MinGW or Visual Studio (CMake)/Windows**: Please read <https://github.com/OpenMathLib/OpenBLAS/docs/nstall.md#visual-studio-native-windows-abi>.
+- **MinGW or Visual Studio (CMake)/Windows**: Please read <https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md#visual-studio--native-windows-abi>.
 - **Darwin/macOS/OSX/iOS**: Already supported on PPC and x86 by the original GotoBLAS, now also on ARM64 but we are not OSX/iOS experts.
-- **FreeBSD**: Supported by the community. We don't actively test the library on this OS.
+- **FreeBSD**: Supported by the community. Basic test coverage is provided by GitHub Actions.
 - **OpenBSD**: Supported by the community. We don't actively test the library on this OS.
 - **NetBSD**: Supported by the community. We don't actively test the library on this OS.
 - **DragonFly BSD**: Supported by the community. We don't actively test the library on this OS.
-- **Android**: Supported by the community. Please read <https://github.com/OpenMathLib/OpenBLAS/docs/install.md#android>.
+- **Android**: Supported by the community. Please read <https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md#android>.
 - **AIX**: Supported on PPC up to POWER10 but testing is increasingly problematic due to lack of publicly available systems
 - **Haiku**: Supported by the community. We don't actively test the library on this OS.
 - **SunOS**: Supported by the community. We don't actively test the library on this OS.
-- **Cortex-M**: Supported by the community. Please read <https://github.com/OpenMathLib/OpenBLAS/docs/install.md#cortex-m>.
+- **Cortex-M**: Supported by the community. Please read <https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md#cortex-m>.
 
 ## Usage
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,15 @@ trigger:
   branches:
     include:
       - develop
+  paths:
+    exclude:
+      - 'docs/**'
+      - '**/*.md'
+pr:
+  paths:
+    exclude:
+      - 'docs/**'
+      - '**/*.md'
 resources:
   containers:
       - container: oneapi-hpckit

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -22,14 +22,24 @@
 | x86_64      | " |macOS11|gmake |arm64| XCode 12.4 | - | | + | - | both | Azure |  |
 | x86_64      | " |macOS11|gmake |arm | XCode 12.4 | - | | + | - | both | Azure |  |
 | x86_64      | " |Alpine Linux(musl)|gmake| - | gcc | gfortran | pthreads | + | - | both | Azure |  |
-| arm64       |Apple M1   |OSX    |CMAKE/XCode| - | LLVM   | - | OpenMP | - | - | static | Cirrus |   |
-| arm64       |Apple M1   |OSX    |CMAKE/Xcode| - | LLVM   | - | OpenMP | - | + | static | Cirrus |  |  
-| arm64       |Apple M1   |OSX    |CMAKE/XCode|x86_64| LLVM| - | - | + | - | static | Cirrus |   |
-| arm64       |Neoverse N1|Linux  |gmake      | -    |gcc10.2| -| pthreads| - | - | both   | Cirrus |   |
-| arm64       |Neoverse N1|Linux  |gmake      | -    |gcc10.2| -| pthreads| - | + | both   | Cirrus |  |
-| arm64       |Neoverse N1|Linux  |gmake      |-     |gcc10.2| -| OpenMP | - | - | both   |Cirrus | 8 |
-| x86_64      | Ryzen|   FreeBSD  |gmake      | - | gcc12.2|gfortran| pthreads| - | - | both | Cirrus | |
-| x86_64      | Ryzen|   FreeBSD  |gmake      |   | gcc12.2|gfortran| pthreads| - | + | both | Cirrus | |
+| arm64       |Apple M1   |macOS14|CMAKE      | - | LLVM   |gfortran| pthreads | + | - | static | Github |  |
+| arm64       |Apple M1   |macOS14|CMAKE      | - | LLVM   |gfortran| pthreads | + | + | static | Github |  |
+| arm64       |Apple M1   |macOS14|CMAKE      | - | LLVM   |gfortran| OpenMP | + | - | static | Github |  |
+| arm64       |Apple M1   |macOS14|CMAKE      | - | LLVM   |gfortran| OpenMP | + | + | static | Github |  |
+| arm64       |Apple M1   |macOS14|gmake      | - | LLVM   |gfortran| pthreads | + | - | both | Github |   |
+| arm64       |Apple M1   |macOS14|gmake      | - | LLVM   |gfortran| pthreads | + | + | both | Github |  |
+| arm64       |Apple M1   |macOS14|gmake      | - | LLVM   |gfortran| OpenMP | + | - | both | Github |  |
+| arm64       |Apple M1   |macOS14|gmake      | - | LLVM   |gfortran| OpenMP | + | + | both | Github |  |
+| arm64       |Apple M1   |macOS26|gmake      |x86_64| XCode| - | | + | - | both | Github |   |
+| arm64       |Apple M1   |macOS26|gmake      |arm64| XCode| - | | + | - | both | Github |   |
+| arm64       |Apple M1   |macOS26|gmake      |arm| AndroidNDK-llvm | - | | - | - | both | Github |   |
+| arm64       |Neoverse N1|Linux  |gmake      | -    |gcc|gfortran| pthreads| - | - | both   | Github |   |
+| arm64       |Neoverse N1|Linux  |gmake      | -    |gcc|gfortran| pthreads| - | + | both   | Github |  |
+| arm64       |Neoverse N1|Linux  |gmake      |-     |gcc|gfortran| OpenMP | - | - | both   | Github |  |
+| arm64       |Graviton3  |Linux  |CMAKE      | - |gcc|gfortran| pthreads| + | - | static | Github | |
+| arm64       |Graviton3  |Linux  |gmake      | - |gcc|gfortran| pthreads| + | - | both | Github | |
+| x86_64      |generic|FreeBSD  |gmake      | - | gcc15|gfortran15| pthreads| - | - | both | Github | |
+| arm64       |generic|FreeBSD  |gmake      | - | gcc15|gfortran15| pthreads| - | - | both | Github | |
 | x86_64       |GENERIC    |QEMU   |gmake| mips64 | gcc | gfortran | pthreads | - | - | static | Github |  |
 | x86_64      |SICORTEX   |QEMU   |gmake| mips64 | gcc | gfortran | pthreads | - | - | static | Github |  |
 | x86_64      |I6400      |QEMU   |gmake| mips64 | gcc | gfortran | pthreads | - | - | static | Github |  |


### PR DESCRIPTION
1. Update the CI job matrix to reflect the GitHub Actions jobs.

2. Replace stale README CI badges for inaccessible services.

3. Fix broken README links in the supported OS section and update the FreeBSD note.

4. Skip the FreeBSD and Azure CI workflows for docs-only changes, completing the follow-up from #5881.