### PR TITLE
Enable RVV ROTM for RISC-V ZVL Targets

### DIFF
--- a/kernel/riscv64/KERNEL.RISCV64_ZVL128B
+++ b/kernel/riscv64/KERNEL.RISCV64_ZVL128B
@@ -71,8 +71,8 @@ DROTKERNEL   = rot_rvv.c
 CROTKERNEL   = zrot_rvv.c
 ZROTKERNEL   = zrot_rvv.c
 
-SROTMKERNEL  = ../generic/rotm.c
-DROTMKERNEL  = ../generic/rotm.c
+SROTMKERNEL  = rotm_rvv.c
+DROTMKERNEL  = rotm_rvv.c
 QROTMKERNEL = ../generic/rotm.c
 
 SSCALKERNEL  = scal_rvv.c

--- a/kernel/riscv64/KERNEL.RISCV64_ZVL256B
+++ b/kernel/riscv64/KERNEL.RISCV64_ZVL256B
@@ -66,8 +66,8 @@ DROTKERNEL   = rot_vector.c
 CROTKERNEL   = zrot_vector.c
 ZROTKERNEL   = zrot_vector.c
 
-SROTMKERNEL  = ../generic/rotm.c
-DROTMKERNEL  = ../generic/rotm.c
+SROTMKERNEL  = rotm_rvv.c
+DROTMKERNEL  = rotm_rvv.c
 QROTMKERNEL = ../generic/rotm.c
 
 SSCALKERNEL  = scal_vector.c

--- a/kernel/riscv64/rotm_rvv.c
+++ b/kernel/riscv64/rotm_rvv.c
@@ -62,6 +62,58 @@ int CNAME(BLASLONG n, FLOAT *dx, BLASLONG incx, FLOAT *dy, BLASLONG incy, FLOAT 
   	dflag = dparam[1];
     if (n <= 0 || dflag == - 2.0) goto L140;
 
+    if (incx == 0 || incy == 0) {
+        BLASLONG i;
+        FLOAT w, z;
+
+        kx = 1;
+        ky = 1;
+        if (incx < 0) {
+            kx = (1 - n) * incx + 1;
+        }
+        if (incy < 0) {
+            ky = (1 - n) * incy + 1;
+        }
+
+        if (dflag < 0.) {
+            dh11 = dparam[2];
+            dh12 = dparam[4];
+            dh21 = dparam[3];
+            dh22 = dparam[5];
+            for (i = 0; i < n; ++i) {
+                w = dx[kx];
+                z = dy[ky];
+                dx[kx] = w * dh11 + z * dh12;
+                dy[ky] = w * dh21 + z * dh22;
+                kx += incx;
+                ky += incy;
+            }
+        } else if (dflag == 0) {
+            dh12 = dparam[4];
+            dh21 = dparam[3];
+            for (i = 0; i < n; ++i) {
+                w = dx[kx];
+                z = dy[ky];
+                dx[kx] = w + z * dh12;
+                dy[ky] = w * dh21 + z;
+                kx += incx;
+                ky += incy;
+            }
+        } else {
+            dh11 = dparam[2];
+            dh22 = dparam[5];
+            for (i = 0; i < n; ++i) {
+                w = dx[kx];
+                z = dy[ky];
+                dx[kx] = w * dh11 + z;
+                dy[ky] = -w + dh22 * z;
+                kx += incx;
+                ky += incy;
+            }
+        }
+        goto L140;
+    }
+
     if (!(incx == incy && incx > 0)) goto L70;
 
     nsteps = n * incx;

--- a/kernel/riscv64/rotm_rvv.c
+++ b/kernel/riscv64/rotm_rvv.c
@@ -229,14 +229,6 @@ L70:
 L80:
     dh12 = dparam[4];
     dh21 = dparam[3];
-    if(incx < 0){
-        incx = -incx;
-        dx -= n*incx;
-    }
-    if(incy < 0){
-        incy = -incy;
-        dy -= n*incy;
-    }
     stride_x = incx * sizeof(FLOAT);
     stride_y = incy * sizeof(FLOAT);
     for (size_t vl; n > 0; n -= vl, dx += vl*incx, dy += vl*incy) {
@@ -255,14 +247,6 @@ L80:
 L100:
     dh11 = dparam[2];
     dh22 = dparam[5];
-    if(incx < 0){
-        incx = -incx;
-        dx -= n*incx;
-    }
-    if(incy < 0){
-        incy = -incy;
-        dy -= n*incy;
-    }
     stride_x = incx * sizeof(FLOAT);
     stride_y = incy * sizeof(FLOAT);
     for (size_t vl; n > 0; n -= vl, dx += vl*incx, dy += vl*incy) {
@@ -283,14 +267,6 @@ L120:
     dh12 = dparam[4];
     dh21 = dparam[3];
     dh22 = dparam[5];
-    if(incx < 0){
-        incx = -incx;
-        dx -= n*incx;
-    }
-    if(incy < 0){
-        incy = -incy;
-        dy -= n*incy;
-    }
     stride_x = incx * sizeof(FLOAT);
     stride_y = incy * sizeof(FLOAT);
     for (size_t vl; n > 0; n -= vl, dx += vl*incx, dy += vl*incy) {


### PR DESCRIPTION
This change fixes incorrect stride handling in `rotm_rvv.c` and enables the RVV ROTM kernel for `RISCV64_ZVL128B` and `RISCV64_ZVL256B`:

- Use `kernel/riscv64/rotm_rvv.c` for `SROTMKERNEL` and `DROTMKERNEL`
- Use a scalar fallback for zero-stride cases to preserve ROTM's sequential update semantics
  > When `incx == 0` or `incy == 0`, the same element is updated repeatedly across iterations, creating a loop-carried dependency. The old RVV path wrote back values computed in parallel from the same original value, which does not match ROTM semantics.
- Preserve signed strides in the general-stride path instead of adjusting `dx`/`dy` a second time for negative strides
  > The generic ROTM path already handles the starting point for negative strides with `kx/ky = (1 - n) * inc + 1`. The old RVV path converted negative strides to positive strides and offset `dx`/`dy` again, which could produce incorrect addresses.

## Build Configuration

Using `ZVL256B` as an example:

```bash
make TARGET=RISCV64_ZVL256B \
     BINARY=64 \
     ARCH=riscv64 \
     CC=gcc \
     HOSTCC=gcc \
     NOFORTRAN=1 \
     NO_LAPACK=1 \
     NUM_THREADS=8
```

Benchmark runtime setting:

```bash
OPENBLAS_NUM_THREADS=1
```

| n | OPENBLAS_LOOPS |
|---:|---:|
| 128 | 20000 |
| 1024 | 10000 |
| 16384 | 1000 |
| 1000000 | 30 |

Benchmark command:

```bash
OPENBLAS_LOOPS=${loops} \
OPENBLAS_INCX=${incx} \
OPENBLAS_INCY=${incy} \
./benchmark/${case}.goto ${n} ${n} 1
```

## Correctness Testing

Correctness was checked with a standalone C test program. The test calls `cblas_srotm` and `cblas_drotm`, computes the expected result with a local scalar reference implementation of BLAS ROTM semantics, and compares the full output vectors element by element.

| Item | Coverage |
|---|---|
| Functions | `srotm`, `drotm` |
| n | `0`, `1`, `2`, `3`, `4`, `7`, `8`, `15`, `16`, `17`, `31`, `32`, `33`, `127`, `128`, `129`, `1000` |
| incx/incy | All combinations of `0`, `1`, `2`, `3`, `-1`, `-2` |
| ROTM flag (`param[0]`) | `-2.0`, `-1.0`, `0.0`, `1.0` |
| Tolerance | `srotm <= 2e-5`, `drotm <= 1e-12` |

All correctness tests passed. The two stride-handling bugs above are fixed, and no new correctness issues were found.

## Performance Results

Test hardware: Spacemit X60. Results are in MFlops; higher is better.

| Function | n | incx | incy | loops | Before | After | Speedup |
|---|---:|---:|---:|---:|---:|---:|---:|
| srotm | 128 | 1 | 1 | 20000 | 786.02 | 1729.06 | +120.0% |
| srotm | 1024 | 1 | 1 | 10000 | 853.40 | 2062.32 | +141.7% |
| srotm | 16384 | 1 | 1 | 1000 | 834.19 | 1780.43 | +113.4% |
| srotm | 1000000 | 1 | 1 | 30 | 835.35 | 1726.60 | +106.7% |
| srotm | 128 | 2 | 3 | 20000 | 800.73 | 1623.78 | +102.8% |
| srotm | 1024 | 2 | 3 | 10000 | 851.05 | 1798.69 | +111.3% |
| srotm | 16384 | 2 | 3 | 1000 | 798.41 | 1233.61 | +54.5% |
| srotm | 1000000 | 2 | 3 | 30 | 716.77 | 802.59 | +12.0% |
| srotm | 128 | -1 | -2 | 20000 | 783.50 | 1637.12 | +108.9% |
| srotm | 1024 | -1 | -2 | 10000 | 855.05 | 1979.75 | +131.5% |
| srotm | 16384 | -1 | -2 | 1000 | 825.95 | 1610.98 | +95.0% |
| srotm | 1000000 | -1 | -2 | 30 | 822.76 | 1269.51 | +54.3% |
| drotm | 128 | 1 | 1 | 20000 | 734.54 | 1584.23 | +115.7% |
| drotm | 1024 | 1 | 1 | 10000 | 788.78 | 1819.94 | +130.7% |
| drotm | 16384 | 1 | 1 | 1000 | 777.95 | 1395.04 | +79.3% |
| drotm | 1000000 | 1 | 1 | 30 | 745.44 | 1019.79 | +36.8% |
| drotm | 128 | 2 | 3 | 20000 | 679.45 | 1317.64 | +93.9% |
| drotm | 1024 | 2 | 3 | 10000 | 674.46 | 847.17 | +25.6% |
| drotm | 16384 | 2 | 3 | 1000 | 468.05 | 496.66 | +6.1% |
| drotm | 1000000 | 2 | 3 | 30 | 396.32 | 403.93 | +1.9% |
| drotm | 128 | -1 | -2 | 20000 | 726.36 | 1396.95 | +92.3% |
| drotm | 1024 | -1 | -2 | 10000 | 782.65 | 1570.49 | +100.7% |
| drotm | 16384 | -1 | -2 | 1000 | 715.93 | 1122.39 | +56.8% |
| drotm | 1000000 | -1 | -2 | 30 | 604.97 | 666.15 | +10.1% |

- `srotm` improves across all tested cases. The contiguous path improves by `+106.7%` to `+141.7%`; the contiguous `drotm` path improves by `+36.8%` to `+130.7%`.
- The negative-stride path passes correctness testing and shows consistent performance gains: `+54.3%` to `+131.5%` for `srotm`, and `+10.1%` to `+100.7%` for `drotm`.
- The weakest gain is on the non-contiguous positive-stride `drotm` path, where `n=1000000, incx=2, incy=3` improves by `+1.9%`. No consistent regression was observed.
