### PR TITLE
Fix CTest command for openblas_utest_ext

### DIFF
--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -153,10 +153,10 @@ set_target_properties( ${OpenBLAS_utest_bin} PROPERTIES COMPILE_DEFINITIONS "_CR
 endif()
 
 #Set output for utest
-set_target_properties( ${OpenBLAS_utest_bin} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set_target_properties( ${OpenBLAS_utest_bin} ${OpenBLAS_utest_ext_bin} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
   string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
-  set_target_properties( ${OpenBLAS_utest_bin} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_CURRENT_BINARY_DIR})
+  set_target_properties( ${OpenBLAS_utest_bin} ${OpenBLAS_utest_ext_bin} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_CURRENT_BINARY_DIR})
 endforeach()
 
 if (MSVC AND BUILD_SHARED_LIBS)
@@ -167,4 +167,4 @@ add_custom_command(TARGET ${OpenBLAS_utest_bin}
 endif()
 
 add_test(${OpenBLAS_utest_bin} ${CMAKE_CURRENT_BINARY_DIR}/${OpenBLAS_utest_bin})
-add_test(${OpenBLAS_utest_ext_bin} ${CMAKE_CURRENT_BINARY_DIR}/${OpenBLAS_utest_bin})
+add_test(${OpenBLAS_utest_ext_bin} ${CMAKE_CURRENT_BINARY_DIR}/${OpenBLAS_utest_ext_bin})


### PR DESCRIPTION
## Summary

This fixes the CMake/CTest registration for `openblas_utest_ext`.

`utest/CMakeLists.txt` builds two separate unit-test executables:

- `openblas_utest`
- `openblas_utest_ext`

However, both CTest entries currently invoke `openblas_utest`. As a result, the `openblas_utest_ext` CTest entry is registered under the right test name but runs the wrong binary.

This PR updates the second `add_test` command so that `openblas_utest_ext` runs the `openblas_utest_ext` executable.

## Details

Before this change, generated CTest metadata looked like this:

```cmake
add_test(openblas_utest "/.../utest/openblas_utest")
add_test(openblas_utest_ext "/.../utest/openblas_utest")
```

After this change, it correctly becomes:

```cmake
add_test(openblas_utest "/.../utest/openblas_utest")
add_test(openblas_utest_ext "/.../utest/openblas_utest_ext")
```

The PR also applies the existing utest runtime output directory settings to `openblas_utest_ext`, matching `openblas_utest`. This keeps the explicit CTest path valid for both test executables, including multi-config generators.

## Validation

Configured a CMake build with:

```sh
cmake -S . -B /private/tmp/openblas-ctest-smoke \
  -DBUILD_WITHOUT_LAPACK=ON \
  -DNOFORTRAN=ON \
  -DTARGET=ARMV8
```

Confirmed the generated CTest file now registers:

```cmake
add_test(openblas_utest_ext "/tmp/openblas-ctest-smoke/utest/openblas_utest_ext")
```

Built the affected test executable:

```sh
cmake --build /private/tmp/openblas-ctest-smoke --target openblas_utest_ext -j 4
```

Ran the corrected CTest entry:

```sh
ctest --test-dir /private/tmp/openblas-ctest-smoke \
  -R '^openblas_utest_ext$' \
  --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 1
```