### PR TITLE
Relax C910V qemu utest timeout

### DIFF
--- a/.github/workflows/c910v.yml
+++ b/.github/workflows/c910v.yml
@@ -93,8 +93,9 @@ jobs:
         run: |
           run_with_retry() {
               local cmd="$1"
-              local time_out=10
-              local retries=10
+              local time_out="${2:-10}"
+              local retries="${3:-10}"
+              local timeout_step="${4:-5}"
               local attempt=0
 
               for ((i=1; i<=retries; i++)); do
@@ -106,7 +107,7 @@ jobs:
                       local exit_code=$?
                       if [ $exit_code -eq 140 ]; then
                           echo "Attempt $i timed out (retrying...)"
-                          time_out=$((time_out + 5))
+                          time_out=$((time_out + timeout_step))
                       else
                           echo "Attempt $i failed with exit code $exit_code. Aborting workflow."
                           exit $exit_code
@@ -121,7 +122,7 @@ jobs:
           export PATH=$GITHUB_WORKSPACE/qemu-install/bin:$PATH
           which qemu-riscv64
           export QEMU_BIN=$(which qemu-riscv64)
-          run_with_retry "$QEMU_BIN ./utest/openblas_utest"
+          run_with_retry "$QEMU_BIN ./utest/openblas_utest" 120 2 30
           run_with_retry "$QEMU_BIN ./utest/openblas_utest_ext"
 
           OPENBLAS_NUM_THREADS=2 qemu-riscv64 ./ctest/xscblat1


### PR DESCRIPTION
## Summary

This relaxes the C910V QEMU timeout for `openblas_utest`.

The timeout showed up while checking #5899, but #5899 only changed CMake/CTest registration. The failing C910V job uses the make build and runs `openblas_utest` directly under QEMU.

## Details

The failing job repeatedly reaches:

```text
TEST 126/128 fork:safety
```

and then restarts the whole unit-test binary with short timeout windows.

This keeps the existing retry defaults, but lets callers override them. Only the observed slow binary gets a larger budget:

```sh
run_with_retry "$QEMU_BIN ./utest/openblas_utest" 120 2 30
run_with_retry "$QEMU_BIN ./utest/openblas_utest_ext"
```

`openblas_utest_ext` keeps the default retry behavior because the observed timeout happens before it runs.

## Scope

Limited to `.github/workflows/c910v.yml`.

## Validation

Checked the relevant Actions history:

- PR #5899 run `29003486034`, job `86079876651`: timed out at `openblas_utest` `fork:safety`.
- Post-merge `develop` run `29007407697`, job `86082261750`: same timeout pattern.
- Prior passing `develop` run `28967557753`, job `85954497464`: same test reached timeout retries before eventually passing.
