### PR TITLE
LoongArch64: avoid SGEMM LA464 ncopy fallthrough from N2 to N1

### DIFF
--- a/kernel/loongarch64/sgemm_ncopy_16_lasx.S
+++ b/kernel/loongarch64/sgemm_ncopy_16_lasx.S
@@ -130,6 +130,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //.L_N2:
 //|   .L_N2_M2:
 //|   .L_N2_M1:
+//|   .L_N2_END:
 //.L_N1:
 //|   .L_N1_M1:
 //.L_N0
@@ -436,7 +437,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     blt          ZERO, I,    .L_N2_M2
 .L_N2_M1:
     andi      I,     M,    0x01
-    beq       I,     ZERO, .L_N1
+    beq       I,     ZERO, .L_N2_END
 
     fld.s     F0,    S1,  0x00
     fld.s     F1,    S2,  0x00
@@ -446,6 +447,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     fst.s       F1,    TD,  0x04
     PTR_ADDI    S2,    S2,  0x04
     PTR_ADDI    TD,    TD,  0x08
+.L_N2_END:
+    andi      J,     N,   0x01
+    beq       ZERO,  J,   .L_N0
 .align 5
 .L_N1:
     move      S1,    TS

--- a/kernel/loongarch64/sgemm_ncopy_8_lasx.S
+++ b/kernel/loongarch64/sgemm_ncopy_8_lasx.S
@@ -105,6 +105,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //.L_N2:
 //|   .L_N2_M2:
 //|   .L_N2_M1:
+//|   .L_N2_END:
 //.L_N1:
 //|   .L_N1_M1:
 //.L_N0
@@ -271,7 +272,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     blt          ZERO, I,    .L_N2_M2
 .L_N2_M1:
     andi      I,     M,    0x01
-    beq       I,     ZERO, .L_N1
+    beq       I,     ZERO, .L_N2_END
 
     fld.s     F0,    S1,  0x00
     fld.s     F1,    S2,  0x00
@@ -281,6 +282,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     fst.s       F1,    TD,  0x04
     PTR_ADDI    S2,    S2,  0x04
     PTR_ADDI    TD,    TD,  0x08
+.L_N2_END:
+    andi      J,     N,   0x01
+    beq       ZERO,  J,   .L_N0
 .align 5
 .L_N1:
     move      S1,    TS


### PR DESCRIPTION
### Problem
The .L_N2 tail path handles a remaining 2-column block. After that path completes, the original code could directly jump or fall through into .L_N1.

However, .L_N1 handles a remaining 1-column block, so entering .L_N1 should depend on N & 1.

The original code used M & 1:
```
.L_N2_M1:
    andi      I,     M,    0x01
    beq       I,     ZERO, .L_N1
```
M & 1 only indicates whether the current 2-column block has one remaining row. It does not indicate whether there is one remaining column.

This can cause the kernel to process an extra column after .L_N2, leading to an out-of-bounds read when the column tail contains 2 but not 1.

For example:
```
N % 8 == 2
N % 8 == 6
```

### Fix
Add an .L_N2_END block and check N & 1 before falling through into .L_N1.

```
.L_N2_M1:
    andi      I,     M,    0x01
    beq       I,     ZERO, .L_N2_END
    ...

.L_N2_END:
    andi      J,     N,   0x01
    beq       ZERO,  J,   .L_N0

.align 5
.L_N1:
```