### PR TITLE
Add a portable XERBLA handler API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,18 +734,46 @@ if(NOT NO_CBLAS)
   set(CBLAS_H ${CMAKE_BINARY_DIR}/generated/cblas.h)
   file(READ ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h CBLAS_H_CONTENTS)
   string(REPLACE "common" "openblas_config" CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS}")
+
+  # Symbol prefix/suffix settings rename exported functions, not C typedefs.
+  # Protect callback type names from the textual function-name rewriting below.
+  string(REPLACE "openblas_dojob_callback" "OPENBLAS_DOJOB_CALLBACK_TYPE"
+    CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+  string(REPLACE "openblas_threads_callback" "OPENBLAS_THREADS_CALLBACK_TYPE"
+    CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+  string(REPLACE "openblas_xerbla_handler" "OPENBLAS_XERBLA_HANDLER_TYPE"
+    CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+
   if (NOT ${SYMBOLPREFIX} STREQUAL "")
-    string(REPLACE " cblas" " ${SYMBOLPREFIX}cblas" CBLAS_H_CONTENTS	"${CBLAS_H_CONTENTS_NEW}")
-    string(REPLACE " openblas" " ${SYMBOLPREFIX}openblas" CBLAS_H_CONTENTS_NEW	"${CBLAS_H_CONTENTS}")
-    string (REPLACE " ${SYMBOLPREFIX}openblas_complex" " openblas_complex" CBLAS_H_CONTENTS	"${CBLAS_H_CONTENTS_NEW}")
-    string(REPLACE " goto" " ${SYMBOLPREFIX}goto" CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS}")
+    string(REPLACE " cblas" " ${SYMBOLPREFIX}cblas"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+    string(REPLACE " openblas" " ${SYMBOLPREFIX}openblas"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+    string(REPLACE " ${SYMBOLPREFIX}openblas_complex" " openblas_complex"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+    string(REPLACE " goto" " ${SYMBOLPREFIX}goto"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
   endif()
   if (NOT ${SYMBOLSUFFIX} STREQUAL "")
-    string(REGEX REPLACE "(cblas[^ (]*)" "\\1${SYMBOLSUFFIX}" CBLAS_H_CONTENTS	"${CBLAS_H_CONTENTS_NEW}")
-    string(REGEX REPLACE "(openblas[^ (]*)" "\\1${SYMBOLSUFFIX}" CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS}")
-    string(REGEX REPLACE "(openblas_complex[^ ]*)${SYMBOLSUFFIX}" "\\1" CBLAS_H_CONTENTS	"${CBLAS_H_CONTENTS_NEW}")
-    string(REGEX REPLACE "(goto[^ (]*)" "\\1${SYMBOLSUFFIX}" CBLAS_H_CONTENTS_NEW	"${CBLAS_H_CONTENTS}")
+    string(REGEX REPLACE "(cblas[A-Za-z0-9_]*)" "\\1${SYMBOLSUFFIX}"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+    string(REGEX REPLACE "(openblas[A-Za-z0-9_]*)" "\\1${SYMBOLSUFFIX}"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+    string(REPLACE "openblas_config${SYMBOLSUFFIX}" "openblas_config"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+    string(REGEX REPLACE "(openblas_complex[A-Za-z0-9_]*)${SYMBOLSUFFIX}" "\\1"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+    string(REGEX REPLACE "(goto[A-Za-z0-9_]*)" "\\1${SYMBOLSUFFIX}"
+      CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
   endif()
+
+  string(REPLACE "OPENBLAS_DOJOB_CALLBACK_TYPE" "openblas_dojob_callback"
+    CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+  string(REPLACE "OPENBLAS_THREADS_CALLBACK_TYPE" "openblas_threads_callback"
+    CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+  string(REPLACE "OPENBLAS_XERBLA_HANDLER_TYPE" "openblas_xerbla_handler"
+    CBLAS_H_CONTENTS_NEW "${CBLAS_H_CONTENTS_NEW}")
+
   file(WRITE ${CBLAS_H} "${CBLAS_H_CONTENTS_NEW}")
   install (FILES ${CBLAS_H} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()

--- a/Makefile.install
+++ b/Makefile.install
@@ -73,7 +73,10 @@ install : 	lib.grd
 
 ifneq ($(NO_CBLAS),1)
 	@echo Generating cblas.h in $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)
-	@cp cblas.h cblas.tmp
+	@sed -e 's/openblas_dojob_callback/OPENBLAS_DOJOB_CALLBACK_TYPE/g' \
+	     -e 's/openblas_threads_callback/OPENBLAS_THREADS_CALLBACK_TYPE/g' \
+	     -e 's/openblas_xerbla_handler/OPENBLAS_XERBLA_HANDLER_TYPE/g' \
+	     cblas.h > cblas.tmp
 ifdef SYMBOLPREFIX
 	@sed 's/cblas[^() ]*/$(SYMBOLPREFIX)&/g' cblas.tmp > cblas.tmp2
 	@sed 's/openblas[^() ]*/$(SYMBOLPREFIX)&/g'  cblas.tmp2 > cblas.tmp
@@ -88,7 +91,11 @@ ifdef SYMBOLSUFFIX
 	@sed 's/\(openblas_complex_\)\([^ ]*\)$(SYMBOLSUFFIX)/\1\2 /g'  cblas.tmp > cblas.tmp2
 	@sed 's/goto[^() ]*/&$(SYMBOLSUFFIX)/g'  cblas.tmp2 > cblas.tmp
 endif
-	@sed 's/common/openblas_config/g' cblas.tmp > "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/cblas.h"
+	@sed -e 's/OPENBLAS_DOJOB_CALLBACK_TYPE/openblas_dojob_callback/g' \
+	     -e 's/OPENBLAS_THREADS_CALLBACK_TYPE/openblas_threads_callback/g' \
+	     -e 's/OPENBLAS_XERBLA_HANDLER_TYPE/openblas_xerbla_handler/g' \
+	     -e 's/common/openblas_config/g' \
+	     cblas.tmp > "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/cblas.h"
 endif
 
 ifneq ($(OSNAME), AIX)

--- a/cblas.h
+++ b/cblas.h
@@ -59,10 +59,12 @@ typedef void (*openblas_dojob_callback)(int thread_num, void *jobdata, int dojob
 typedef void (*openblas_threads_callback)(int sync, openblas_dojob_callback dojob, int numjobs, size_t jobdata_elsize, void *jobdata, int dojob_data);
 void openblas_set_threads_callback_function(openblas_threads_callback callback);
 
-/* Set the process-wide error handler called by XERBLA. The callback's routine
- * name is valid for name_length bytes and is not necessarily NUL-terminated.
- * Installation is thread-safe, returns the previous handler, and accepts NULL
- * to restore OpenBLAS' default handler. */
+/* Replace the XERBLA handler for this OpenBLAS instance and return the
+ * previous handler. Passing NULL restores the default. Callbacks may run
+ * concurrently and must be thread-safe. The name and info pointers are valid
+ * only during the callback; name spans name_length bytes and need not be
+ * NUL-terminated. Replacement is thread-safe but does not wait for in-flight
+ * calls, so the previous handler must remain loaded until they complete. */
 #ifndef OPENBLAS_XERBLA_HANDLER_DEFINED
 #define OPENBLAS_XERBLA_HANDLER_DEFINED
 typedef void (*openblas_xerbla_handler)(const char *name,

--- a/cblas.h
+++ b/cblas.h
@@ -59,6 +59,18 @@ typedef void (*openblas_dojob_callback)(int thread_num, void *jobdata, int dojob
 typedef void (*openblas_threads_callback)(int sync, openblas_dojob_callback dojob, int numjobs, size_t jobdata_elsize, void *jobdata, int dojob_data);
 void openblas_set_threads_callback_function(openblas_threads_callback callback);
 
+/* Set the process-wide error handler called by XERBLA. The callback's routine
+ * name is valid for name_length bytes and is not necessarily NUL-terminated.
+ * Installation is thread-safe, returns the previous handler, and accepts NULL
+ * to restore OpenBLAS' default handler. */
+#ifndef OPENBLAS_XERBLA_HANDLER_DEFINED
+#define OPENBLAS_XERBLA_HANDLER_DEFINED
+typedef void (*openblas_xerbla_handler)(const char *name,
+                                        const blasint *info,
+                                        size_t name_length);
+#endif
+openblas_xerbla_handler openblas_set_xerbla(openblas_xerbla_handler handler);
+
 #ifdef OPENBLAS_OS_LINUX
 /* Sets thread affinity for OpenBLAS threads. `thread_idx` is in [0, openblas_get_num_threads()-1]. */
 int openblas_setaffinity(int thread_idx, size_t cpusetsize, cpu_set_t* cpu_set);

--- a/common.h
+++ b/common.h
@@ -880,6 +880,26 @@ typedef struct {
 #endif
 
 #include "common_interface.h"
+
+/* Internal declaration of the public C XERBLA callback API. Keep this out of
+ * common_interface.h, whose contents are copied verbatim into f77blas.h and
+ * are not adjusted for SYMBOLPREFIX/SYMBOLSUFFIX by the CMake build. */
+#ifndef ASSEMBLER
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifndef OPENBLAS_XERBLA_HANDLER_DEFINED
+#define OPENBLAS_XERBLA_HANDLER_DEFINED
+typedef void (*openblas_xerbla_handler)(const char *name,
+                                        const blasint *info,
+                                        size_t name_length);
+#endif
+openblas_xerbla_handler openblas_set_xerbla(openblas_xerbla_handler handler);
+#ifdef __cplusplus
+}
+#endif
+#endif
+
 #ifdef SANITY_CHECK
 #include "common_reference.h"
 #endif

--- a/ctest/CMakeLists.txt
+++ b/ctest/CMakeLists.txt
@@ -18,6 +18,7 @@ if(WIN32)
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_cblas_helper.ps1
 "$ErrorActionPreference = \"Stop\"\n"
 "Get-Content $args[1] | & $args[0]\n"
+"exit $LASTEXITCODE\n"
 )
 set(test_helper powershell -ExecutionPolicy Bypass "${CMAKE_CURRENT_BINARY_DIR}/test_cblas_helper.ps1")
 else()

--- a/ctest/c_c2chke.c
+++ b/ctest/c_c2chke.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -36,11 +29,7 @@ void F77_c2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/ctest/c_c2chke.c
+++ b/ctest/c_c2chke.c
@@ -810,6 +810,8 @@ void F77_c2chke(char *rout) {
    }
    if (cblas_ok == TRUE)
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("******* %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_c3chke.c
+++ b/ctest/c_c3chke.c
@@ -1692,6 +1692,8 @@ void  F77_c3chke(char *  rout) {
 
    if (cblas_ok == 1 )
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_c3chke.c
+++ b/ctest/c_c3chke.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -39,11 +32,7 @@ void  F77_c3chke(char *  rout) {
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
 
    if (strncmp( sf,"cblas_cgemm"   ,11)==0) {

--- a/ctest/c_c3chke_3m.c
+++ b/ctest/c_c3chke_3m.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -39,11 +32,7 @@ void  F77_c3chke(char *  rout) {
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
 
    if (strncmp( sf,"cblas_cgemm3m"   ,13)==0) {

--- a/ctest/c_c3chke_3m.c
+++ b/ctest/c_c3chke_3m.c
@@ -1920,6 +1920,8 @@ void  F77_c3chke(char *  rout) {
 
    if (cblas_ok == 1 )
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_d2chke.c
+++ b/ctest/c_d2chke.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -34,11 +27,7 @@ void F77_d2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/ctest/c_d2chke.c
+++ b/ctest/c_d2chke.c
@@ -773,6 +773,8 @@ void F77_d2chke(char *rout) {
    }
    if (cblas_ok == TRUE)
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("******* %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_d3chke.c
+++ b/ctest/c_d3chke.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -34,11 +27,7 @@ void F77_d3chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/ctest/c_d3chke.c
+++ b/ctest/c_d3chke.c
@@ -1255,6 +1255,8 @@ void F77_d3chke(char *rout) {
    }
    if (cblas_ok == TRUE )
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_s2chke.c
+++ b/ctest/c_s2chke.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -34,11 +27,7 @@ void F77_s2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/ctest/c_s2chke.c
+++ b/ctest/c_s2chke.c
@@ -773,6 +773,8 @@ void F77_s2chke(char *rout) {
    }
    if (cblas_ok == TRUE)
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("******* %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_s3chke.c
+++ b/ctest/c_s3chke.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -34,11 +27,7 @@ void F77_s3chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/ctest/c_s3chke.c
+++ b/ctest/c_s3chke.c
@@ -1257,6 +1257,8 @@ void F77_s3chke(char *rout) {
    }
    if (cblas_ok == TRUE )
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_xerbla.c
+++ b/ctest/c_xerbla.c
@@ -8,16 +8,8 @@
 void cblas_xerbla(blasint info, char *rout, char *form, ...)
 {
    extern int cblas_lerr, cblas_info, cblas_ok;
-   extern int link_xerbla;
    extern int RowMajorStrg;
    extern char *cblas_rout;
-
-   /* Initially, c__3chke will call this routine with
-    * global variable link_xerbla=1, and F77_xerbla will set link_xerbla=0.
-    * This is done to fool the linker into loading these subroutines first
-    * instead of ones in the CBLAS or the legacy BLAS library.
-    */
-   if (link_xerbla) return;
 
    if (cblas_rout != NULL && strcmp(cblas_rout, rout) != 0){
       printf("***** XERBLA WAS CALLED WITH SRNAME = <%s> INSTEAD OF <%s> *******\n", rout, cblas_rout);
@@ -78,44 +70,27 @@ void cblas_xerbla(blasint info, char *rout, char *form, ...)
    }
 
    if (info != cblas_info){
-      printf("***** XERBLA WAS CALLED WITH INFO = %d INSTEAD OF %d in %s *******\n",info, cblas_info, rout);
+      printf("***** XERBLA WAS CALLED WITH INFO = %lld INSTEAD OF %lld in %s *******\n",
+             (long long)info, (long long)cblas_info, rout);
       cblas_lerr = PASSED;
       cblas_ok = FALSE;
    } else cblas_lerr = FAILED;
 }
 
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo)
-#else
-void F77_xerbla(char *srname, void *vinfo)
-#endif
+static void cblas_test_xerbla(const char *srname, const blasint *info,
+                              size_t length)
 {
-#ifdef F77_Char
-   char *srname;
-#endif
-
+   extern int cblas_ok;
    char rout[] = {'c','b','l','a','s','_','\0','\0','\0','\0','\0','\0','\0'};
+   blasint i;
 
-#ifdef F77_Integer
-   F77_Integer *info=vinfo;
-   F77_Integer i;
-   extern F77_Integer link_xerbla;
-#else
-   int *info=vinfo;
-   int i;
-   extern int link_xerbla;
-#endif
-#ifdef F77_Char
-   srname = F2C_STR(F77_srname, XerblaStrLen);
-#endif
-
-   /* See the comment in cblas_xerbla() above */
-   if (link_xerbla)
-   {
-      link_xerbla = 0;
+   if (length < 6) {
+      printf("***** XERBLA WAS CALLED WITH AN INVALID ROUTINE NAME LENGTH *******\n");
+      cblas_ok = FALSE;
       return;
    }
-   for(i=0;  i  < 6; i++) rout[i+6] = tolower(srname[i]);
+
+   for(i=0;  i  < 6; i++) rout[i+6] = tolower((unsigned char)srname[i]);
    for(i=11; i >= 9; i--) if (rout[i] == ' ') rout[i] = '\0';
 
    /* We increment *info by 1 since the CBLAS interface adds one more
@@ -124,14 +99,6 @@ void F77_xerbla(char *srname, void *vinfo)
    cblas_xerbla(*info+1,rout,"");
 }
 
-#ifdef USE64BITINT
-#undef int
-#endif
-
-int    BLASFUNC(xerbla)(char *name, blasint *info, blasint length) {
-
-  F77_xerbla(name, info);
-  return 0;
-};
-
-
+void cblas_test_set_xerbla(void) {
+   openblas_set_xerbla(cblas_test_xerbla);
+}

--- a/ctest/c_xerbla.c
+++ b/ctest/c_xerbla.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>
 #include <string.h>
@@ -101,4 +102,8 @@ static void cblas_test_xerbla(const char *srname, const blasint *info,
 
 void cblas_test_set_xerbla(void) {
    openblas_set_xerbla(cblas_test_xerbla);
+}
+
+void cblas_test_fail(void) {
+   exit(EXIT_FAILURE);
 }

--- a/ctest/c_z2chke.c
+++ b/ctest/c_z2chke.c
@@ -810,6 +810,8 @@ void F77_z2chke(char *rout) {
    }
    if (cblas_ok == TRUE)
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("******* %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_z2chke.c
+++ b/ctest/c_z2chke.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -36,11 +29,7 @@ void F77_z2chke(char *rout) {
    extern int RowMajorStrg;
    extern char *cblas_rout;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;

--- a/ctest/c_z3chke.c
+++ b/ctest/c_z3chke.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -39,11 +32,7 @@ void  F77_z3chke(char *  rout) {
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
 
 

--- a/ctest/c_z3chke.c
+++ b/ctest/c_z3chke.c
@@ -1694,6 +1694,8 @@ void  F77_z3chke(char *  rout) {
 
    if (cblas_ok == 1 )
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/c_z3chke_3m.c
+++ b/ctest/c_z3chke_3m.c
@@ -4,21 +4,14 @@
 #include "cblas_test.h"
 
 int cblas_ok, cblas_lerr, cblas_info;
-int link_xerbla=TRUE;
 char *cblas_rout;
-
-#ifdef F77_Char
-void F77_xerbla(F77_Char F77_srname, void *vinfo);
-#else
-void F77_xerbla(char *srname, void *vinfo);
-#endif
 
 void chkxer(void) {
    extern int cblas_ok, cblas_lerr, cblas_info;
-   extern int link_xerbla;
    extern char *cblas_rout;
    if (cblas_lerr == 1 ) {
-      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %d NOT DETECTED BY %s *****\n", cblas_info, cblas_rout);
+      printf("***** ILLEGAL VALUE OF PARAMETER NUMBER %lld NOT DETECTED BY %s *****\n",
+             (long long)cblas_info, cblas_rout);
       cblas_ok = 0 ;
    }
    cblas_lerr = 1 ;
@@ -39,11 +32,7 @@ void  F77_z3chke(char *  rout) {
    cblas_ok = TRUE ;
    cblas_lerr = PASSED ;
 
-   if (link_xerbla) /* call these first to link */
-   {
-      cblas_xerbla(cblas_info,cblas_rout,"");
-      F77_xerbla(cblas_rout,&cblas_info);
-   }
+   cblas_test_set_xerbla();
 
 
 

--- a/ctest/c_z3chke_3m.c
+++ b/ctest/c_z3chke_3m.c
@@ -1924,6 +1924,8 @@ void  F77_z3chke(char *  rout) {
 
    if (cblas_ok == 1 )
        printf(" %-12s PASSED THE TESTS OF ERROR-EXITS\n", cblas_rout);
-   else
+   else {
        printf("***** %s FAILED THE TESTS OF ERROR-EXITS *******\n",cblas_rout);
+       cblas_test_fail();
+   }
 }

--- a/ctest/cblas_test.h
+++ b/ctest/cblas_test.h
@@ -30,6 +30,8 @@
 #define  INVALID       -1
 #define  UNDEFINED     -1
 
+void cblas_test_set_xerbla(void);
+
 typedef struct { float real; float imag; } CBLAS_TEST_COMPLEX;
 typedef struct { double real; double imag; } CBLAS_TEST_ZOMPLEX;
 

--- a/ctest/cblas_test.h
+++ b/ctest/cblas_test.h
@@ -31,6 +31,7 @@
 #define  UNDEFINED     -1
 
 void cblas_test_set_xerbla(void);
+void cblas_test_fail(void);
 
 typedef struct { float real; float imag; } CBLAS_TEST_COMPLEX;
 typedef struct { double real; double imag; } CBLAS_TEST_ZOMPLEX;

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -47,10 +47,7 @@ BLAS-like and conversion functions for `hfloat16` (available when OpenBLAS was c
 * `int openblas_set_affinity(int thread_index, size_t cpusetsize, cpu_set_t *cpuset)` sets the CPU affinity mask of the given thread
   to the provided cpuset. Only available on Linux, with semantics identical to `pthread_setaffinity_np`.
 * `openblas_set_thread_callback_function` overrides the default multithreading backend with the provided argument
-* `openblas_set_xerbla(openblas_xerbla_handler handler)` installs a process-wide XERBLA error handler and returns the
-  previous handler. Passing `NULL` restores the default handler. Handlers must be thread-safe because they may be called
-  concurrently. Replacing a handler is thread-safe but does not wait for in-progress calls to return, so the previous handler's
-  code must remain loaded until those calls finish. The `name` and `info` pointers are valid only during the callback. `name`
-  points to `name_length` valid bytes and need not be NUL-terminated; the length stops before the first NUL but otherwise includes
-  trailing spaces. Handler registration works normally on ELF platforms. For backward compatibility, an application-provided
-  strong `xerbla` symbol still overrides the OpenBLAS dispatcher and bypasses the registered handler.
+* `openblas_set_xerbla(openblas_xerbla_handler handler)` replaces the XERBLA handler for the current OpenBLAS
+  instance and returns the previous handler; passing `NULL` restores the default. Callbacks may be invoked concurrently
+  and therefore must be thread-safe. `name` is valid for `name_length` bytes during the callback and need not be
+  NUL-terminated. On ELF platforms, an application-provided strong `xerbla` symbol bypasses the registered handler.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -47,9 +47,10 @@ BLAS-like and conversion functions for `hfloat16` (available when OpenBLAS was c
 * `int openblas_set_affinity(int thread_index, size_t cpusetsize, cpu_set_t *cpuset)` sets the CPU affinity mask of the given thread
   to the provided cpuset. Only available on Linux, with semantics identical to `pthread_setaffinity_np`.
 * `openblas_set_thread_callback_function` overrides the default multithreading backend with the provided argument
-* `openblas_set_xerbla(openblas_xerbla_handler handler)` installs a process-wide XERBLA error handler and returns the previous handler.
-  Passing `NULL` restores the default handler. Handler replacement is thread-safe, but callbacks may run concurrently and must
-  therefore be thread-safe. The routine name and error information are valid only for the duration of the callback. The name is
-  valid for the supplied length, is not necessarily NUL-terminated, and retains any trailing spaces; when a NUL is present, the
-  reported length stops before the first NUL. Replacing a handler does not wait for callbacks already in progress. On ELF platforms,
-  a legacy strong `xerbla` definition takes precedence over this dispatcher.
+* `openblas_set_xerbla(openblas_xerbla_handler handler)` installs a process-wide XERBLA error handler and returns the
+  previous handler. Passing `NULL` restores the default handler. Handlers must be thread-safe because they may be called
+  concurrently. Replacing a handler is thread-safe but does not wait for in-progress calls to return, so the previous handler's
+  code must remain loaded until those calls finish. The `name` and `info` pointers are valid only during the callback. `name`
+  points to `name_length` valid bytes and need not be NUL-terminated; the length stops before the first NUL but otherwise includes
+  trailing spaces. Handler registration works normally on ELF platforms. For backward compatibility, an application-provided
+  strong `xerbla` symbol still overrides the OpenBLAS dispatcher and bypasses the registered handler.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -47,8 +47,9 @@ BLAS-like and conversion functions for `hfloat16` (available when OpenBLAS was c
 * `int openblas_set_affinity(int thread_index, size_t cpusetsize, cpu_set_t *cpuset)` sets the CPU affinity mask of the given thread
   to the provided cpuset. Only available on Linux, with semantics identical to `pthread_setaffinity_np`.
 * `openblas_set_thread_callback_function` overrides the default multithreading backend with the provided argument
-* `openblas_set_xerbla(openblas_xerbla_handler handler)` installs a process-wide XERBLA error handler and returns the previous one.
-  Installation is thread-safe, and passing `NULL` restores the default handler. The callback receives a read-only routine name,
-  error parameter number and normalized name length (excluding a terminating NUL when present); the name is not guaranteed to be
-  NUL-terminated. On ELF platforms, a legacy strong `xerbla` definition still takes precedence over this dispatcher. Callback code
-  must remain loaded until the handler has been replaced and all concurrent BLAS calls have completed.
+* `openblas_set_xerbla(openblas_xerbla_handler handler)` installs a process-wide XERBLA error handler and returns the previous handler.
+  Passing `NULL` restores the default handler. Handler replacement is thread-safe, but callbacks may run concurrently and must
+  therefore be thread-safe. The routine name and error information are valid only for the duration of the callback. The name is
+  valid for the supplied length, is not necessarily NUL-terminated, and retains any trailing spaces; when a NUL is present, the
+  reported length stops before the first NUL. Replacing a handler does not wait for callbacks already in progress. On ELF platforms,
+  a legacy strong `xerbla` definition takes precedence over this dispatcher.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -47,3 +47,8 @@ BLAS-like and conversion functions for `hfloat16` (available when OpenBLAS was c
 * `int openblas_set_affinity(int thread_index, size_t cpusetsize, cpu_set_t *cpuset)` sets the CPU affinity mask of the given thread
   to the provided cpuset. Only available on Linux, with semantics identical to `pthread_setaffinity_np`.
 * `openblas_set_thread_callback_function` overrides the default multithreading backend with the provided argument
+* `openblas_set_xerbla(openblas_xerbla_handler handler)` installs a process-wide XERBLA error handler and returns the previous one.
+  Installation is thread-safe, and passing `NULL` restores the default handler. The callback receives a read-only routine name,
+  error parameter number and normalized name length (excluding a terminating NUL when present); the name is not guaranteed to be
+  NUL-terminated. On ELF platforms, a legacy strong `xerbla` definition still takes precedence over this dispatcher. Callback code
+  must remain loaded until the handler has been replaced and all concurrent BLAS calls have completed.

--- a/driver/others/xerbla.c
+++ b/driver/others/xerbla.c
@@ -36,8 +36,10 @@
 /* or implied, of The University of Texas at Austin.                 */
 /*********************************************************************/
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "common.h"
 
 #if defined(OS_WINDOWS) && (defined(__MINGW32__) || defined(__MINGW64__))
@@ -46,31 +48,67 @@
 #define printf	_cprintf
 #endif
 
-#ifdef INTERFACE64
-#define MSGFMT " ** On entry to %6s parameter number %2ld had an illegal value\n" 
-#else
-#define MSGFMT " ** On entry to %6s parameter number %2d had an illegal value\n"
-#endif
+#define MSGFMT " ** On entry to %6.*s parameter number %2lld had an illegal value\n"
+
+static size_t openblas_xerbla_name_length(const char *message,
+                                          blasint length) {
+  const char *terminator;
+
+  if (message == NULL || length <= 0) return 0;
+
+  terminator = memchr(message, '\0', (size_t)length);
+  if (terminator != NULL) return (size_t)(terminator - message);
+
+  return (size_t)length;
+}
+
+static void openblas_xerbla_default(const char *message, const blasint *info,
+                                    size_t length) {
+  int precision = length > INT_MAX ? INT_MAX : (int)length;
+
+  printf(MSGFMT, precision, message == NULL ? "" : message,
+         (long long)*info);
+}
+
+static openblas_xerbla_handler openblas_xerbla = openblas_xerbla_default;
+static volatile BLASULONG openblas_xerbla_lock = 0;
+
+openblas_xerbla_handler
+openblas_set_xerbla(openblas_xerbla_handler handler) {
+  openblas_xerbla_handler previous;
+
+  if (handler == NULL) handler = openblas_xerbla_default;
+
+  blas_lock(&openblas_xerbla_lock);
+  previous = openblas_xerbla;
+  openblas_xerbla = handler;
+  blas_unlock(&openblas_xerbla_lock);
+
+  return previous;
+}
+
+static int openblas_xerbla_dispatch(char *message, blasint *info,
+                                    blasint length) {
+  openblas_xerbla_handler handler;
+  size_t name_length = openblas_xerbla_name_length(message, length);
+
+  blas_lock(&openblas_xerbla_lock);
+  handler = openblas_xerbla;
+  blas_unlock(&openblas_xerbla_lock);
+
+  handler(message, info, name_length);
+  return 0;
+}
 
 #ifdef __ELF__
-int __xerbla(char *message, blasint *info, blasint length){
-
-  printf(MSGFMT,
-	  message, *info);
-
-  return 0;
+int __xerbla(char *message, blasint *info, blasint length) {
+  return openblas_xerbla_dispatch(message, info, length);
 }
 
-int BLASFUNC(xerbla)(char *, blasint *, blasint) __attribute__ ((weak, alias ("__xerbla")));
-
+int BLASFUNC(xerbla)(char *, blasint *, blasint)
+  __attribute__ ((weak, alias ("__xerbla")));
 #else
-
-int BLASFUNC(xerbla)(char *message, blasint *info, blasint length){
-
-  printf(MSGFMT,
-	  message, *info);
-
-  return 0;
+int BLASFUNC(xerbla)(char *message, blasint *info, blasint length) {
+  return openblas_xerbla_dispatch(message, info, length);
 }
-
 #endif

--- a/exports/gensymbol
+++ b/exports/gensymbol
@@ -4112,10 +4112,13 @@ case "$p1" in
         done
 
         for obj in $no_underscore_objs; do
+            [ "$obj" = "openblas_set_xerbla" ] && continue
             printf '\t%s%s%s=%s  @%s\n' \
                 "$symbolprefix" "$obj" "$symbolsuffix" "$obj" "$count"
             count=`expr $count + 1`
         done
+        printf '\t%sopenblas_set_xerbla%s=openblas_set_xerbla  @%s\n' \
+            "$symbolprefix" "$symbolsuffix" "$count"
     ;;
 
     win2khpl)

--- a/exports/gensymbol
+++ b/exports/gensymbol
@@ -182,6 +182,7 @@ misc_no_underscore_objs="
     openblas_get_config
     openblas_get_corename
     openblas_set_threads_callback_function
+    openblas_set_xerbla
 "
 
 misc_underscore_objs=""

--- a/exports/gensymbol.pl
+++ b/exports/gensymbol.pl
@@ -178,6 +178,7 @@
     openblas_get_config,
     openblas_get_corename,
     openblas_set_threads_callback_function,
+    openblas_set_xerbla,
 );
 
 @misc_underscore_objs = (

--- a/exports/gensymbol.pl
+++ b/exports/gensymbol.pl
@@ -4054,9 +4054,11 @@ if ($ARGV[0] eq "win2k"){
 
 
     foreach $objs (@no_underscore_objs) {
+        next if $objs eq "openblas_set_xerbla";
         print "\t",$symbolprefix,$objs,$symbolsuffix,"=$objs","  \@", $count, "\n";
         $count ++;
     }
+    print "\t",$symbolprefix,"openblas_set_xerbla",$symbolsuffix,"=openblas_set_xerbla  \@",$count,"\n";
 
     exit(0);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,9 +31,22 @@ if (USE_GEMM3M)
 	endif ()
 endif ()
 
+add_library(openblas_test_xerbla OBJECT xerbla_test.c)
+# Static test executables provide their own XERBLA and must continue to test
+# link-time interposition. Shared-only tests use the explicit handler because
+# calls originating in a DLL or dylib cannot portably bind to that definition.
+if (BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
+	target_compile_definitions(openblas_test_xerbla PRIVATE
+		OPENBLAS_TEST_USE_XERBLA_HANDLER)
+endif()
+
 foreach(test_bin ${OpenBLAS_Tests})
 	add_executable(${test_bin} ${test_bin}.f)
-target_link_libraries(${test_bin} ${OpenBLAS_LIBNAME})
+	if (test_bin MATCHES "blat(2|3)(_3m)?$")
+		target_sources(${test_bin} PRIVATE
+			$<TARGET_OBJECTS:openblas_test_xerbla>)
+	endif()
+	target_link_libraries(${test_bin} ${OpenBLAS_LIBNAME})
 endforeach()
 
 if (BUILD_BFLOAT16)
@@ -62,29 +75,45 @@ endif()
 if(WIN32)
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_helper.ps1
 "[Console]::InputEncoding = New-Object Text.UTF8Encoding $false\n"
-"if (Test-Path $args[2]) { Remove-Item -Force $args[2] } \n"
 "$ErrorActionPreference = \"Stop\"\n"
-"Get-Content $args[1] | & $args[0]\n" 
-"If ((Get-Content $args[2] | %{$_ -match \"FATAL\"}) -contains $true) {\n"
-"echo Error in $args[1]:\n"
-"Get-Content $args[2] \n"
-"exit 1\n"
-"} else {\n"
-"exit 0\n"
+"if (Test-Path -LiteralPath $args[2]) { Remove-Item -LiteralPath $args[2] -Force }\n"
+"Get-Content -LiteralPath $args[1] | & $args[0]\n"
+"$testExitCode = $LASTEXITCODE\n"
+"if ($testExitCode -ne 0) { exit $testExitCode }\n"
+"if (-not (Test-Path -LiteralPath $args[2])) {\n"
+"  Write-Host \"Missing test summary: $($args[2])\"\n"
+"  exit 1\n"
 "}\n"
+"if (Select-String -LiteralPath $args[2] -Pattern \"FATAL|FAILED\" -Quiet) {\n"
+"  Write-Host \"Error in $($args[1]):\"\n"
+"  Get-Content -LiteralPath $args[2]\n"
+"  exit 1\n"
+"}\n"
+"exit 0\n"
 )
 set(helper_prefix powershell -ExecutionPolicy Bypass "${CMAKE_CURRENT_BINARY_DIR}/test_helper.ps1")
 else()
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_helper.sh
-"rm -f $3\n"
-"$1 < $2\n"
-"grep -q FATAL $3\n"
-"if [ $? -eq 0 ]; then\n"
-"echo Error\n"
-"exit 1\n"
-"else\n"
-"exit 0\n"
+"rm -f \"$3\"\n"
+"remove_status=$?\n"
+"if [ $remove_status -ne 0 ]; then\n"
+"  echo \"Unable to remove stale test summary: $3\"\n"
+"  exit $remove_status\n"
 "fi\n"
+"\"$1\" < \"$2\"\n"
+"test_exit_code=$?\n"
+"if [ $test_exit_code -ne 0 ]; then exit $test_exit_code; fi\n"
+"if [ ! -f \"$3\" ]; then\n"
+"  echo \"Missing test summary: $3\"\n"
+"  exit 1\n"
+"fi\n"
+"grep -q -e FATAL -e FAILED \"$3\"\n"
+"summary_status=$?\n"
+"case $summary_status in\n"
+"  0) echo \"Error in $2:\"; cat \"$3\"; exit 1 ;;\n"
+"  1) exit 0 ;;\n"
+"  *) echo \"Unable to read test summary: $3\"; exit $summary_status ;;\n"
+"esac\n"
 )
 set(helper_prefix sh "${CMAKE_CURRENT_BINARY_DIR}/test_helper.sh")
 endif()

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,6 +37,16 @@ endif
 # override CFLAGS += -std=c11 -Wall -Werror
 
 SUPPORT_GEMM3M = 0
+XERBLA_TEST = xerbla_test.$(SUFFIX)
+
+define CHECK_TEST_SUMMARY
+@status=0; $(GREP) -q -e FATAL -e FAILED "$(1)" || status=$$?; \
+case $$status in \
+  0) cat "$(1)"; exit 1 ;; \
+  1) ;; \
+  *) echo "Unable to read test summary: $(1)"; exit $$status ;; \
+esac
+endef
 
 ifeq ($(ARCH), x86)
 SUPPORT_GEMM3M = 1
@@ -146,85 +156,85 @@ ifneq ($(CROSS), 1)
 	rm -f ?BLAT2.SUMM
 ifeq ($(BUILD_BFLOAT16),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./test_bgemv$(EXE) > BBLAT2.SUMM
-	@$(GREP) -q FATAL BBLAT2.SUMM && cat BBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,BBLAT2.SUMM)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./test_sbgemv$(EXE) > SBBLAT2.SUMM
-	@$(GREP) -q FATAL SBBLAT2.SUMM && cat SBBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBBLAT2.SUMM)
 endif
 ifeq ($(BUILD_HFLOAT16),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./test_shgemv$(EXE) > SHBLAT2.SUMM
-	@$(GREP) -q FATAL SHBLAT2.SUMM && cat SHBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SHBLAT2.SUMM)
 endif
 ifeq ($(BUILD_SINGLE),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./sblat2$(EXE) < ./sblat2.dat
-	@$(GREP) -q FATAL SBLAT2.SUMM && cat SBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBLAT2.SUMM)
 endif
 ifeq ($(BUILD_DOUBLE),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./dblat2$(EXE) < ./dblat2.dat
-	@$(GREP) -q FATAL DBLAT2.SUMM && cat DBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,DBLAT2.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./cblat2$(EXE) < ./cblat2.dat
-	@$(GREP) -q FATAL CBLAT2.SUMM && cat CBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT2.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./zblat2$(EXE) < ./zblat2.dat
-	@$(GREP) -q FATAL ZBLAT2.SUMM && cat ZBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT2.SUMM)
 endif
 ifdef SMP
 	rm -f ?BLAT2.SUMM
 ifeq ($(USE_OPENMP), 1)
 ifeq ($(BUILD_BFLOAT16),1)
 	OMP_NUM_THREADS=2 ./test_bgemv$(EXE) > BBLAT2.SUMM
-	@$(GREP) -q FATAL BBLAT2.SUMM && cat BBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,BBLAT2.SUMM)
 	OMP_NUM_THREADS=2 ./test_sbgemv$(EXE) > SBBLAT2.SUMM
-	@$(GREP) -q FATAL SBBLAT2.SUMM && cat SBBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBBLAT2.SUMM)
 endif
 ifeq ($(BUILD_HFLOAT16),1)
 	OMP_NUM_THREADS=2 ./test_shgemv$(EXE) > SHBLAT2.SUMM
-	@$(GREP) -q FATAL SHBLAT2.SUMM && cat SHBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SHBLAT2.SUMM)
 endif
 ifeq ($(BUILD_SINGLE),1)
 	OMP_NUM_THREADS=2 ./sblat2$(EXE) < ./sblat2.dat
-	@$(GREP) -q FATAL SBLAT2.SUMM && cat SBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBLAT2.SUMM)
 endif
 ifeq ($(BUILD_DOUBLE),1)
 	OMP_NUM_THREADS=2 ./dblat2$(EXE) < ./dblat2.dat
-	@$(GREP) -q FATAL DBLAT2.SUMM && cat DBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,DBLAT2.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX),1)
 	OMP_NUM_THREADS=2 ./cblat2$(EXE) < ./cblat2.dat
-	@$(GREP) -q FATAL CBLAT2.SUMM && cat CBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT2.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OMP_NUM_THREADS=2 ./zblat2$(EXE) < ./zblat2.dat
-	@$(GREP) -q FATAL ZBLAT2.SUMM && cat ZBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT2.SUMM)
 endif
 else
 ifeq ($(BUILD_BFLOAT16),1)
 	OMP_NUM_THREADS=2 ./test_bgemv$(EXE) > BBLAT2.SUMM
-	@$(GREP) -q FATAL BBLAT2.SUMM && cat BBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,BBLAT2.SUMM)
 	OMP_NUM_THREADS=2 ./test_sbgemv$(EXE) > SBBLAT2.SUMM
-	@$(GREP) -q FATAL SBBLAT2.SUMM && cat SBBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBBLAT2.SUMM)
 endif
 ifeq ($(BUILD_HFLOAT16),1)
 	OMP_NUM_THREADS=2 ./test_shgemv$(EXE) > SHBLAT2.SUMM
-	@$(GREP) -q FATAL SHBLAT2.SUMM && cat SHBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SHBLAT2.SUMM)
 endif
 ifeq ($(BUILD_SINGLE),1)
 	OPENBLAS_NUM_THREADS=2 ./sblat2$(EXE) < ./sblat2.dat
-	@$(GREP) -q FATAL SBLAT2.SUMM && cat SBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBLAT2.SUMM)
 endif
 ifeq ($(BUILD_DOUBLE),1)
 	OPENBLAS_NUM_THREADS=2 ./dblat2$(EXE) < ./dblat2.dat
-	@$(GREP) -q FATAL DBLAT2.SUMM && cat DBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,DBLAT2.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX),1)
 	OPENBLAS_NUM_THREADS=2 ./cblat2$(EXE) < ./cblat2.dat
-	@$(GREP) -q FATAL CBLAT2.SUMM && cat CBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT2.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OPENBLAS_NUM_THREADS=2 ./zblat2$(EXE) < ./zblat2.dat
-	@$(GREP) -q FATAL ZBLAT2.SUMM && cat ZBLAT2.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT2.SUMM)
 endif
 endif
 endif
@@ -273,86 +283,86 @@ ifneq ($(CROSS), 1)
 	rm -f ?BLAT3.SUMM
 ifeq ($(BUILD_BFLOAT16),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./test_sbgemm$(EXE) > SBBLAT3.SUMM
-	@$(GREP) -q FATAL SBBLAT3.SUMM && cat SBBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBBLAT3.SUMM)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./test_bgemm$(EXE) > BBLAT3.SUMM
-	@$(GREP) -q FATAL BBLAT3.SUMM && cat BBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,BBLAT3.SUMM)
 endif
 ifeq ($(BUILD_HFLOAT16),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./test_shgemm > SHBLAT3.SUMM
-	@$(GREP) -q FATAL SHBLAT3.SUMM && cat SHBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SHBLAT3.SUMM)
 endif
 ifeq ($(BUILD_SINGLE),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./sblat3$(EXE) < ./sblat3.dat
-	@$(GREP) -q FATAL SBLAT3.SUMM && cat SBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBLAT3.SUMM)
 endif
 ifeq ($(BUILD_DOUBLE),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./dblat3$(EXE) < ./dblat3.dat
-	@$(GREP) -q FATAL DBLAT3.SUMM && cat DBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,DBLAT3.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./cblat3$(EXE) < ./cblat3.dat
-	@$(GREP) -q FATAL CBLAT3.SUMM && cat CBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT3.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./zblat3$(EXE) < ./zblat3.dat
-	@$(GREP) -q FATAL ZBLAT3.SUMM && cat ZBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT3.SUMM)
 endif
 ifdef SMP
 	rm -f ?BLAT3.SUMM
 ifeq ($(USE_OPENMP), 1)
 ifeq ($(BUILD_BFLOAT16),1)
 	OMP_NUM_THREADS=2 ./test_sbgemm$(EXE) > SBBLAT3.SUMM
-	@$(GREP) -q FATAL SBBLAT3.SUMM && cat SBBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBBLAT3.SUMM)
 	OMP_NUM_THREADS=2 ./test_bgemm$(EXE) > BBLAT3.SUMM
-	@$(GREP) -q FATAL BBLAT3.SUMM && cat BBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,BBLAT3.SUMM)
 endif
 ifeq ($(BUILD_HFLOAT16),1)
 	OMP_NUM_THREADS=2 ./test_shgemm > SHBLAT3.SUMM
-	@$(GREP) -q FATAL SHBLAT3.SUMM && cat SHBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SHBLAT3.SUMM)
 endif
 
 ifeq ($(BUILD_SINGLE),1)
 	OMP_NUM_THREADS=2 ./sblat3$(EXE) < ./sblat3.dat
-	@$(GREP) -q FATAL SBLAT3.SUMM && cat SBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBLAT3.SUMM)
 endif
 ifeq ($(BUILD_DOUBLE),1)
 	OMP_NUM_THREADS=2 ./dblat3$(EXE) < ./dblat3.dat
-	@$(GREP) -q FATAL DBLAT3.SUMM && cat DBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,DBLAT3.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX),1)
 	OMP_NUM_THREADS=2 ./cblat3$(EXE) < ./cblat3.dat
-	@$(GREP) -q FATAL CBLAT3.SUMM && cat CBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT3.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OMP_NUM_THREADS=2 ./zblat3$(EXE) < ./zblat3.dat
-	@$(GREP) -q FATAL ZBLAT3.SUMM && cat ZBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT3.SUMM)
 endif
 else
 ifeq ($(BUILD_BFLOAT16),1)
 	OPENBLAS_NUM_THREADS=2 ./test_sbgemm$(EXE) > SBBLAT3.SUMM
-	@$(GREP) -q FATAL SBBLAT3.SUMM && cat SBBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBBLAT3.SUMM)
 	OPENBLAS_NUM_THREADS=2 ./test_bgemm$(EXE) > BBLAT3.SUMM
-	@$(GREP) -q FATAL BBLAT3.SUMM && cat BBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,BBLAT3.SUMM)
 endif
 ifeq ($(BUILD_HFLOAT16),1)
 	OPENBLAS_NUM_THREADS=2 ./test_shgemm > SHBLAT3.SUMM
-	@$(GREP) -q FATAL SHBLAT3.SUMM && cat SHBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SHBLAT3.SUMM)
 endif
 ifeq ($(BUILD_SINGLE),1)
 	OPENBLAS_NUM_THREADS=2 ./sblat3$(EXE) < ./sblat3.dat
-	@$(GREP) -q FATAL SBLAT3.SUMM && cat SBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,SBLAT3.SUMM)
 endif
 ifeq ($(BUILD_DOUBLE),1)
 	OPENBLAS_NUM_THREADS=2 ./dblat3$(EXE) < ./dblat3.dat
-	@$(GREP) -q FATAL DBLAT3.SUMM && cat DBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,DBLAT3.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX),1)
 	OPENBLAS_NUM_THREADS=2 ./cblat3$(EXE) < ./cblat3.dat
-	@$(GREP) -q FATAL CBLAT3.SUMM && cat CBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT3.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OPENBLAS_NUM_THREADS=2 ./zblat3$(EXE) < ./zblat3.dat
-	@$(GREP) -q FATAL ZBLAT3.SUMM && cat ZBLAT3.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT3.SUMM)
 endif
 endif
 endif
@@ -364,31 +374,31 @@ ifneq ($(CROSS), 1)
 	rm -f ?BLAT3_3M.SUMM
 ifeq ($(BUILD_COMPLEX),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./cblat3_3m$(EXE) < ./cblat3_3m.dat
-	@$(GREP) -q FATAL CBLAT3_3M.SUMM && cat CBLAT3_3M.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT3_3M.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./zblat3_3m$(EXE) < ./zblat3_3m.dat
-	@$(GREP) -q FATAL ZBLAT3_3M.SUMM && cat ZBLAT3_3M.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT3_3M.SUMM)
 endif
 ifdef SMP
 	rm -f ?BLAT3_3M.SUMM
 ifeq ($(USE_OPENMP), 1)
 ifeq ($(BUILD_COMPLEX),1)
 	OMP_NUM_THREADS=2 ./cblat3_3m$(EXE) < ./cblat3_3m.dat
-	@$(GREP) -q FATAL CBLAT3_3M.SUMM && cat CBLAT3_3M.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT3_3M.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OMP_NUM_THREADS=2 ./zblat3_3m$(EXE) < ./zblat3_3m.dat
-	@$(GREP) -q FATAL ZBLAT3_3M.SUMM && cat ZBLAT3_3M.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT3_3M.SUMM)
 endif
 else
 ifeq ($(BUILD_COMPLEX),1)
 	OPENBLAS_NUM_THREADS=2 ./cblat3_3m$(EXE) < ./cblat3_3m.dat
-	@$(GREP) -q FATAL CBLAT3_3M.SUMM && cat CBLAT3_3M.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,CBLAT3_3M.SUMM)
 endif
 ifeq ($(BUILD_COMPLEX16),1)
 	OPENBLAS_NUM_THREADS=2 ./zblat3_3m$(EXE) < ./zblat3_3m.dat
-	@$(GREP) -q FATAL ZBLAT3_3M.SUMM && cat ZBLAT3_3M.SUMM || exit 0
+	$(call CHECK_TEST_SUMMARY,ZBLAT3_3M.SUMM)
 endif
 endif
 endif
@@ -420,26 +430,29 @@ endif
 endif
 endif
 
+$(XERBLA_TEST): xerbla_test.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
 ifeq ($(BUILD_SINGLE),1)
 sblat1$(EXE) : sblat1.$(SUFFIX) ../$(LIBNAME)
 	$(FC) $(FLDFLAGS) -o $@ sblat1.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-sblat2$(EXE) : sblat2.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ sblat2.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+sblat2$(EXE) : sblat2.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ sblat2.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-sblat3$(EXE) : sblat3.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ sblat3.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+sblat3$(EXE) : sblat3.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ sblat3.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 endif
 
 ifeq ($(BUILD_DOUBLE),1)
 dblat1$(EXE) : dblat1.$(SUFFIX) ../$(LIBNAME)
 	$(FC) $(FLDFLAGS) -o $@ dblat1.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-dblat2$(EXE) : dblat2.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ dblat2.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+dblat2$(EXE) : dblat2.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ dblat2.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-dblat3$(EXE) : dblat3.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ dblat3.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+dblat3$(EXE) : dblat3.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ dblat3.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 else
 dblat2$(EXE):
 dblat3$(EXE):
@@ -453,22 +466,22 @@ ifeq ($(BUILD_COMPLEX),1)
 cblat1$(EXE) : cblat1.$(SUFFIX) ../$(LIBNAME)
 	$(FC) $(FLDFLAGS) -o $@ cblat1.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-cblat2$(EXE) : cblat2.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ cblat2.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+cblat2$(EXE) : cblat2.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ cblat2.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-cblat3$(EXE) : cblat3.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ cblat3.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+cblat3$(EXE) : cblat3.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ cblat3.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 endif
 
 ifeq ($(BUILD_COMPLEX16),1)
 zblat1$(EXE) : zblat1.$(SUFFIX) ../$(LIBNAME)
 	$(FC) $(FLDFLAGS) -o $@ zblat1.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-zblat2$(EXE) : zblat2.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ zblat2.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+zblat2$(EXE) : zblat2.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ zblat2.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-zblat3$(EXE) : zblat3.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ zblat3.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+zblat3$(EXE) : zblat3.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ zblat3.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 endif
 
 ifeq ($(BUILD_BFLOAT16),1)
@@ -495,13 +508,13 @@ endif
 
 
 ifeq ($(BUILD_COMPLEX),1)
-cblat3_3m$(EXE) : cblat3_3m.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ cblat3_3m.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+cblat3_3m$(EXE) : cblat3_3m.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ cblat3_3m.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 endif
 
 ifeq ($(BUILD_COMPLEX16),1)
-zblat3_3m$(EXE) : zblat3_3m.$(SUFFIX) ../$(LIBNAME)
-	$(FC) $(FLDFLAGS) -o $@ zblat3_3m.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
+zblat3_3m$(EXE) : zblat3_3m.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME)
+	$(FC) $(FLDFLAGS) -o $@ zblat3_3m.$(SUFFIX) $(XERBLA_TEST) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 endif
 
 

--- a/test/cblat2.f
+++ b/test/cblat2.f
@@ -2401,6 +2401,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/cblat3.f
+++ b/test/cblat3.f
@@ -2019,6 +2019,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/cblat3_3m.f
+++ b/test/cblat3_3m.f
@@ -1976,6 +1976,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/dblat2.f
+++ b/test/dblat2.f
@@ -2351,6 +2351,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/dblat3.f
+++ b/test/dblat3.f
@@ -1873,6 +1873,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/sblat2.f
+++ b/test/sblat2.f
@@ -2351,6 +2351,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/sblat3.f
+++ b/test/sblat3.f
@@ -1873,6 +1873,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/xerbla_test.c
+++ b/test/xerbla_test.c
@@ -1,0 +1,51 @@
+/***************************************************************************
+Copyright (c) 2026, The OpenBLAS Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the OpenBLAS project nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "common.h"
+
+#ifdef OPENBLAS_TEST_USE_XERBLA_HANDLER
+static void openblas_test_xerbla(const char *name, const blasint *info,
+                                 size_t name_length) {
+  blasint fortran_length = (blasint)name_length;
+  blasint fortran_info;
+
+  if (name == NULL || info == NULL || fortran_length < 0 ||
+      (size_t)fortran_length != name_length)
+    return;
+
+  fortran_info = *info;
+  BLASFUNC(xerbla)((char *)name, &fortran_info, fortran_length);
+}
+#endif
+
+void BLASFUNC(openblas_test_set_xerbla)(void) {
+#ifdef OPENBLAS_TEST_USE_XERBLA_HANDLER
+  openblas_set_xerbla(openblas_test_xerbla);
+#endif
+}

--- a/test/zblat2.f
+++ b/test/zblat2.f
@@ -2408,6 +2408,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/zblat3.f
+++ b/test/zblat3.f
@@ -2026,6 +2026,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/test/zblat3_3m.f
+++ b/test/zblat3_3m.f
@@ -1979,6 +1979,7 @@
 *     .. Common blocks ..
       COMMON             /INFOC/INFOT, NOUTC, OK, LERR
 *     .. Executable Statements ..
+      CALL OPENBLAS_TEST_SET_XERBLA
 *     OK is set to .FALSE. by the special version of XERBLA or by CHKXER
 *     if anything is wrong.
       OK = .TRUE.

--- a/utest/test_extensions/common.h
+++ b/utest/test_extensions/common.h
@@ -45,7 +45,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 extern int check_error(void);
 extern void set_xerbla(char* current_rout, int expected_info);
-extern int BLASFUNC(xerbla)(char *name, blasint *info, blasint length);
 
 extern void srand_generate(float *alpha, blasint n);
 extern void drand_generate(double *alpha, blasint n);

--- a/utest/test_extensions/xerbla.c
+++ b/utest/test_extensions/xerbla.c
@@ -31,6 +31,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **********************************************************************************/
 
+#include <limits.h>
 #include "utest/openblas_utest.h"
 #include "common.h"
 
@@ -41,6 +42,7 @@ static char *rout;
 static void test_xerbla(const char *srname, const blasint *vinfo, size_t length)
 {
    blasint info = *vinfo;
+   int name_length = length > (size_t)INT_MAX ? INT_MAX : (int)length;
 
    if (rout != NULL &&
        (length != strlen(rout) || memcmp(rout, srname, length) != 0)) {
@@ -50,8 +52,8 @@ static void test_xerbla(const char *srname, const blasint *vinfo, size_t length)
    }
 
    if (info != _info){
-      printf("***** XERBLA WAS CALLED WITH INFO = %lld INSTEAD OF %d in %s *******\n",
-             (long long)info, _info, srname);
+      printf("***** XERBLA WAS CALLED WITH INFO = %lld INSTEAD OF %d in %.*s *******\n",
+             (long long)info, _info, name_length, srname == NULL ? "" : srname);
       lerr = TRUE;
       ok = FALSE;
    } else lerr = FALSE;

--- a/utest/test_extensions/xerbla.c
+++ b/utest/test_extensions/xerbla.c
@@ -31,41 +31,55 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **********************************************************************************/
 
+#include "utest/openblas_utest.h"
 #include "common.h"
 
-static int link_xerbla=TRUE;
+static int handler_installed = FALSE;
 static int lerr, _info, ok;
 static char *rout;
 
-static void F77_xerbla(char *srname, void *vinfo)
+static void test_xerbla(const char *srname, const blasint *vinfo, size_t length)
 {
-   blasint info=*(blasint*)vinfo;
+   blasint info = *vinfo;
 
-   if (link_xerbla)
-   {
-      link_xerbla = 0;
-      return;
-   }
-
-   if (rout != NULL && strcmp(rout, srname) != 0){
-      printf("***** XERBLA WAS CALLED WITH SRNAME = <%s> INSTEAD OF <%s> *******\n", srname, rout);
+   if (rout != NULL &&
+       (length != strlen(rout) || memcmp(rout, srname, length) != 0)) {
+      printf("***** XERBLA WAS CALLED WITH AN UNEXPECTED SRNAME INSTEAD OF <%s> *******\n",
+             rout);
       ok = FALSE;
    }
 
    if (info != _info){
-      printf("***** XERBLA WAS CALLED WITH INFO = %d INSTEAD OF %d in %s *******\n",info, _info, srname);
+      printf("***** XERBLA WAS CALLED WITH INFO = %lld INSTEAD OF %d in %s *******\n",
+             (long long)info, _info, srname);
       lerr = TRUE;
       ok = FALSE;
    } else lerr = FALSE;
 }
 
-/**  
-* error function redefinition 
-*/
-int BLASFUNC(xerbla)(char *name, blasint *info, blasint length)
+static void alternate_xerbla(const char *srname, const blasint *vinfo,
+                             size_t length)
 {
-  F77_xerbla(name, info);
-  return 0;
+   (void) srname;
+   (void) vinfo;
+   (void) length;
+}
+
+CTEST(openblas_extensions, xerbla_handler_registration)
+{
+   openblas_xerbla_handler original;
+   openblas_xerbla_handler previous;
+   openblas_xerbla_handler restored;
+   openblas_xerbla_handler default_handler;
+
+   original = openblas_set_xerbla(test_xerbla);
+   previous = openblas_set_xerbla(alternate_xerbla);
+   restored = openblas_set_xerbla(NULL);
+   default_handler = openblas_set_xerbla(original);
+
+   ASSERT_TRUE(previous == test_xerbla);
+   ASSERT_TRUE(restored == alternate_xerbla);
+   ASSERT_TRUE(default_handler != NULL);
 }
 
 int check_error(void) {
@@ -78,8 +92,10 @@ int check_error(void) {
 }
 
 void set_xerbla(char* current_rout, int expected_info){
-   if (link_xerbla) /* call these first to link */
-      F77_xerbla(rout, &_info);
+   if (!handler_installed) {
+      openblas_set_xerbla(test_xerbla);
+      handler_installed = TRUE;
+   }
 
    ok = TRUE;
    lerr = TRUE;


### PR DESCRIPTION
After #5899 corrected the CTest registration, the Windows ARM64 shared-library job exposed failures in the `xerbla_*` extension tests: calls originating in the OpenBLAS DLL did not reach the test executable's `xerbla` override.

#5901 works around this Windows DLL symbol-resolution limitation by switching the CI job to a static build. This PR instead adds an explicit XERBLA handler API for shared-library users and tests, and prevents BLAS and CBLAS error-exit failures from passing silently.

## Changes

- Adds `openblas_set_xerbla`, with handler replacement and `NULL` reset support.
- Preserves the Fortran ABI and ELF strong-symbol interposition while normalizing routine-name lengths.
- Preserves callback types in prefixed and suffixed installs without changing existing Windows export ordinals.
- Uses explicit handlers where interposition is unavailable and propagates BLAS and CBLAS test failures through CTest and Make.