### PR TITLE
Simplify `num_cpu_avail()` syntax

### DIFF
--- a/cblas.h
+++ b/cblas.h
@@ -40,6 +40,39 @@ extern "C" {
 /*Set the number of threads on runtime.*/
 void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
+/*
+ * Intent:
+ *   Sets the thread-local number of threads that OpenBLAS functions should request.
+ *   This thread-local number only affects the current execution thread
+ *   and, when set, overrides the global default.
+ *   This is useful for controlling nested parallelism.
+ *   For example when the caller's own (e.g. OpenMP) threads each invoke
+ *   OpenBLAS, `num_threads` determines how many threads OpenBLAS may use
+ *   per such call, instead of the process-wide default of
+ *   `omp_get_max_threads()`.
+ *
+ *   The intent of this was likely to match MKL's `mkl_set_num_threads_local()`
+ *   but implementation may not live up to the original intent yet.
+ *
+ * TODO:
+ *   Currently the implementation doesn't really do any of that:
+ *   * The setting is NOT thread-local.
+ *   * This function currently just calls `openblas_set_num_threads(num_threads)`,
+ *     changing the same process-wide thread count as that function,
+ *     and additionally records `num_threads` in an internal (global, not per-thread)
+ *     variable that is only consulted when OpenBLAS is invoked from within
+ *     a caller's OpenMP parallel region and the user has not made an
+ *     explicit thread-count choice.
+ *   * There is no special handling of `num_threads == 0`
+ *     (or other MKL-style reset values); the value is forwarded to
+ *     `openblas_set_num_threads()`, where values < 1 are treated
+ *     as "use the default" and large values are clamped to the number of cores.
+ *
+ * Returns the *previous* number of threads (as reported by
+ * `openblas_get_num_threads()`), so the caller can save and later restore it.
+ *
+ * On single-threaded OpenBLAS builds this is a no-op that returns 1.
+ */
 int openblas_set_num_threads_local(int num_threads);
 
 /*Get the number of threads on runtime.*/

--- a/common_thread.h
+++ b/common_thread.h
@@ -138,10 +138,19 @@ typedef struct blas_queue {
 extern int blas_server_avail;
 extern int blas_omp_number_max;
 extern int blas_omp_threads_local;
+extern int blas_is_num_threads_set_explicitly;
 
 static __inline int num_cpu_avail(int level) {
 
 #ifdef USE_OPENMP
+  /* If the user explicitly called openblas_set_num_threads(),
+     respect that setting instead of overriding it with
+     `omp_get_max_threads()` below (which is to get a default
+     in case the user hasn't made an explicit choice). */
+  if (blas_is_num_threads_set_explicitly) {
+    return blas_cpu_number;
+  }
+
 int openmp_nthreads;
 	openmp_nthreads=omp_get_max_threads();
 	if (omp_in_parallel()) openmp_nthreads = blas_omp_threads_local;

--- a/common_thread.h
+++ b/common_thread.h
@@ -151,27 +151,19 @@ static __inline int num_cpu_avail(int level) {
     return blas_cpu_number;
   }
 
-int openmp_nthreads;
-	openmp_nthreads=omp_get_max_threads();
-	if (omp_in_parallel()) openmp_nthreads = blas_omp_threads_local;
-#endif
+  int openmp_nthreads = omp_in_parallel() ? blas_omp_threads_local : omp_get_max_threads();
 
-#ifndef USE_OPENMP 
-  if (blas_cpu_number == 1
-#else
-     if (openmp_nthreads == 1 
-#endif
-      ) return 1;        
+  if (openmp_nthreads == 1) return 1;
 
-#ifdef USE_OPENMP
-     if (openmp_nthreads > blas_omp_number_max){
+  if (openmp_nthreads > blas_omp_number_max) {
 #ifdef DEBUG
-     fprintf(stderr,"WARNING - more OpenMP threads requested (%d) than available (%d)\n",openmp_nthreads,blas_omp_number_max);
+    fprintf(stderr, "WARNING - more OpenMP threads requested (%d) than available (%d)\n", openmp_nthreads, blas_omp_number_max);
 #endif
-     openmp_nthreads = blas_omp_number_max;
-     }
-     if (blas_cpu_number != openmp_nthreads) {
-	  goto_set_num_threads(openmp_nthreads);
+    openmp_nthreads = blas_omp_number_max;
+  }
+
+  if (blas_cpu_number != openmp_nthreads) {
+    goto_set_num_threads(openmp_nthreads); // mutates `blas_cpu_number`
   }
 #endif
 

--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -70,6 +70,7 @@
 int blas_server_avail = 0;
 int blas_omp_number_max = 0;
 int blas_omp_threads_local = 1;
+int blas_is_num_threads_set_explicitly = 0; // tracks whether the user called openblas_set_num_threads()
 
 extern int openblas_omp_adaptive_env(void);
 
@@ -122,7 +123,7 @@ void goto_set_num_threads(int num_threads) {
 
 }
 void openblas_set_num_threads(int num_threads) {
-
+	blas_is_num_threads_set_explicitly = 1;
 	goto_set_num_threads(num_threads);
 }
 
@@ -145,7 +146,7 @@ extern int openblas_omp_num_threads_env(void);
 
    if(blas_omp_number_max <= 0)
 	   blas_omp_number_max= openblas_omp_num_threads_env();
-   if (blas_omp_number_max <= 0) 
+   if (blas_omp_number_max <= 0)
 	   blas_omp_number_max=MAX_CPU_NUMBER;
 #else
     blas_omp_number_max = omp_get_max_threads();
@@ -365,14 +366,14 @@ static void exec_threads(int thread_num, blas_queue_t *queue, int buf_index){
 #ifdef BUILD_COMPLEX16
 	    sb = (void *)(((BLASLONG)sa + ((ZGEMM_P * ZGEMM_Q * 2 * sizeof(double)
 					    + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
-#else 
+#else
 fprintf(stderr,"UNHANDLED COMPLEX16\n");
 #endif
 	  } else if ((queue -> mode & BLAS_PREC) == BLAS_SINGLE) {
 #ifdef BUILD_COMPLEX
 	    sb = (void *)(((BLASLONG)sa + ((CGEMM_P * CGEMM_Q * 2 * sizeof(float)
 					    + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
-#else 
+#else
 fprintf(stderr,"UNHANDLED COMPLEX\n");
 #endif
 	  } else {

--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -69,7 +69,7 @@
 
 int blas_server_avail = 0;
 int blas_omp_number_max = 0;
-int blas_omp_threads_local = 1;
+int blas_omp_threads_local = 1; // num threads to use when already inside omp_in_parallel()
 int blas_is_num_threads_set_explicitly = 0; // tracks whether the user called openblas_set_num_threads()
 
 extern int openblas_omp_adaptive_env(void);


### PR DESCRIPTION
* [ ] Based on #5808, merge that first.
* [ ] Get @martin-frbg clarification on comment from https://github.com/OpenMathLib/OpenBLAS/pull/5808#issuecomment-4943877382
  > so nothing to do with forcing OMP parallel jobs inside an OMP_PARALLEL region