### PR TITLE
RISC-V: cache-aware GEMM blocking (get_L2_size + blas_set_parameter)

### DIFF
--- a/common_macro.h
+++ b/common_macro.h
@@ -2712,7 +2712,7 @@
 #ifndef ASSEMBLER
 #if !defined(DYNAMIC_ARCH) \
   && (defined(ARCH_X86) || defined(ARCH_X86_64) || defined(ARCH_IA64) || defined(ARCH_MIPS64) || defined(ARCH_ARM64) \
-      || defined(ARCH_LOONGARCH64) || defined(ARCH_E2K) || defined(ARCH_ALPHA))
+      || defined(ARCH_LOONGARCH64) || defined(ARCH_E2K) || defined(ARCH_ALPHA) || defined(ARCH_RISCV64))
 extern BLASLONG gemm_offset_a;
 extern BLASLONG gemm_offset_b;
 extern BLASLONG bgemm_p;

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1220,7 +1220,7 @@ UNLOCK_COMMAND(&alloc_lock);
       if (!blas_num_threads) blas_cpu_number = blas_get_cpu_number();
 #endif
 
-#if defined(ARCH_X86) || defined(ARCH_X86_64) || defined(ARCH_IA64) || defined(ARCH_MIPS64) || defined(ARCH_ARM64) || defined(ARCH_LOONGARCH64)
+#if defined(ARCH_X86) || defined(ARCH_X86_64) || defined(ARCH_IA64) || defined(ARCH_MIPS64) || defined(ARCH_ARM64) || defined(ARCH_LOONGARCH64) || defined(ARCH_RISCV64)
 #ifndef DYNAMIC_ARCH
       blas_set_parameter();
 #endif
@@ -2822,7 +2822,7 @@ void *blas_memory_alloc(int procpos){
     if (!blas_num_threads) blas_cpu_number = blas_get_cpu_number();
 #endif
 
-#if defined(ARCH_X86) || defined(ARCH_X86_64) || defined(ARCH_IA64) || defined(ARCH_MIPS64) || defined(ARCH_ARM64) || defined(ARCH_LOONGARCH64)
+#if defined(ARCH_X86) || defined(ARCH_X86_64) || defined(ARCH_IA64) || defined(ARCH_MIPS64) || defined(ARCH_ARM64) || defined(ARCH_LOONGARCH64) || defined(ARCH_RISCV64)
 #ifndef DYNAMIC_ARCH
     blas_set_parameter();
 #endif

--- a/driver/others/parameter.c
+++ b/driver/others/parameter.c
@@ -902,3 +902,53 @@ void blas_set_parameter(void)
 }
 
 #endif
+
+#if defined(ARCH_RISCV64)
+
+#include <stdio.h>
+
+/* RISC-V has no architectural cache-size query (cf. x86 CPUID / LoongArch
+   CPUCFG), so read the L2 (level 2, unified) size from Linux sysfs and fall
+   back to 512 KB. Returns the L2 size in kilobytes. */
+int get_L2_size(void) {
+  int size = 0;
+#if defined(OS_LINUX) || defined(OS_ANDROID)
+  int idx;
+  for (idx = 0; idx <= 4; idx++) {
+    char path[80]; FILE *fp; int level = 0; long val = 0; char unit = 0;
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/level", idx);
+    fp = fopen(path, "r"); if (fp == NULL) continue;
+    if (fscanf(fp, "%d", &level) != 1) { fclose(fp); continue; }
+    fclose(fp); if (level != 2) continue;
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/size", idx);
+    fp = fopen(path, "r"); if (fp == NULL) continue;
+    if (fscanf(fp, "%ld%c", &val, &unit) >= 1) {
+      if (unit == 'M' || unit == 'm') val *= 1024;
+      if (unit == 'G' || unit == 'g') val *= 1024 * 1024;
+      size = (int)val;
+    }
+    fclose(fp); if (size > 0) break;
+  }
+#endif
+  if (size <= 0) size = 512;
+  return size;
+}
+
+void blas_set_parameter(void) {
+#if defined(SGEMM_DEFAULT_P_BASE)
+  /* Scale each precision's packed-A dimension P from the detected L2, relative
+     to the size the active core's base blocking targets (RISCV_L2_REFERENCE_KB).
+     The bases come from the core's own param.h block, so this is not tied to any
+     single core; Q and R keep their param.h defaults. */
+  int l2    = get_L2_size();   /* KB */
+  int scale = l2 / RISCV_L2_REFERENCE_KB;
+  if (scale < 1) scale = 1;
+  if (scale > 4) scale = 4;
+  sgemm_p = SGEMM_DEFAULT_P_BASE * scale;
+  dgemm_p = DGEMM_DEFAULT_P_BASE * scale;
+  cgemm_p = CGEMM_DEFAULT_P_BASE * scale;
+  zgemm_p = ZGEMM_DEFAULT_P_BASE * scale;
+#endif
+}
+
+#endif

--- a/param.h
+++ b/param.h
@@ -3265,10 +3265,27 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SHGEMM_DEFAULT_P 128
 #undef SBGEMM_DEFAULT_P
 #define SBGEMM_DEFAULT_P 128
-#define SGEMM_DEFAULT_P 128
-#define DGEMM_DEFAULT_P 64
-#define CGEMM_DEFAULT_P 64
-#define ZGEMM_DEFAULT_P 64
+/* Base packed-A (P) blocking for this core. On static builds blas_set_parameter()
+   scales P from the L2 cache detected at runtime, relative to RISCV_L2_REFERENCE_KB
+   (the L2 size these bases target); Q and R keep their param.h defaults. A cache
+   equal to the reference reproduces the stock blocking. DYNAMIC_ARCH uses the
+   literals directly (kernel/setparam-ref.c fills the gotoblas table from them). */
+#define RISCV_L2_REFERENCE_KB 512
+#define SGEMM_DEFAULT_P_BASE 128
+#define DGEMM_DEFAULT_P_BASE 64
+#define CGEMM_DEFAULT_P_BASE 64
+#define ZGEMM_DEFAULT_P_BASE 64
+#if defined(DYNAMIC_ARCH)
+#define SGEMM_DEFAULT_P SGEMM_DEFAULT_P_BASE
+#define DGEMM_DEFAULT_P DGEMM_DEFAULT_P_BASE
+#define CGEMM_DEFAULT_P CGEMM_DEFAULT_P_BASE
+#define ZGEMM_DEFAULT_P ZGEMM_DEFAULT_P_BASE
+#else
+#define SGEMM_DEFAULT_P sgemm_p
+#define DGEMM_DEFAULT_P dgemm_p
+#define CGEMM_DEFAULT_P cgemm_p
+#define ZGEMM_DEFAULT_P zgemm_p
+#endif
 
 #undef SHGEMM_DEFAULT_Q
 #define SHGEMM_DEFAULT_Q 128


### PR DESCRIPTION
# RISC-V: cache-aware GEMM blocking (get_L2_size + blas_set_parameter)

## Summary

RISC-V is currently the only major architecture without a `get_L2_size()` / `blas_set_parameter()` implementation, so the GEMM cache-blocking parameters (`P`/`Q`/`R`) are fixed at compile time regardless of the actual L2 cache. This PR adds cache-aware blocking for RISC-V, mirroring the existing x86 / LoongArch mechanism.

Because the blocking is now derived from the L2 cache detected at runtime rather than a fixed compile-time constant, **future RISC-V cores will get more optimal blocking automatically**. The RISC-V hardware landscape is moving quickly — new cores are arriving with progressively larger and more varied L2 caches — and this lets a single library binary adapt its GEMM blocking to each part instead of shipping one hand-picked value per target (or, as today, one value for all). It also gives the RISC-V port the same runtime-tuning hook x86/LoongArch already use, so future per-core tuning has somewhere to live.

## What it does

- **`get_L2_size()` (`ARCH_RISCV64`)** — reads the level-2 (unified) cache size from Linux sysfs (`/sys/devices/system/cpu/cpu0/cache/index*/{level,size}`). RISC-V has no architectural cache-size query (x86 CPUID / LoongArch CPUCFG), so sysfs is the portable source; falls back to 512 KB when unavailable.
- **`blas_set_parameter()` (`ARCH_RISCV64`)** — scales the packed-A dimension `P` from the detected L2, relative to a per-core reference cache size. The base `P` values and the reference (`*_DEFAULT_P_BASE`, `RISCV_L2_REFERENCE_KB`) live in each core's `param.h` block, so the function carries **no hard-coded, core-specific numbers** and is a no-op for cores that don't declare a base; `Q` and `R` keep their `param.h` defaults.
- Wires `ARCH_RISCV64` into the `blas_set_parameter()` call sites (`driver/others/memory.c`) and the runtime-parameter extern declarations (`common_macro.h`).
- `param.h` `RISCV64_ZVL256B`: declares the per-core base blocking + reference and maps the `*_DEFAULT_P` macros to the runtime variables for static builds; **`DYNAMIC_ARCH` keeps the literals** (see below). `Q` and `R` are unchanged.

## DYNAMIC_ARCH

`kernel/setparam-ref.c`'s RISC-V `init_parameter()` initialises the `gotoblas` table with `TABLE_NAME.sgemm_p = SGEMM_DEFAULT_P`, and `blas_set_parameter()` is not called on the dynamic path. So the `param.h` change is gated: `#if defined(DYNAMIC_ARCH)` keeps the integer literals (dynamic builds behave exactly as before), `#else` uses the runtime variables (static builds get the cache-aware path).

## Calibration / scope

`blas_set_parameter()` carries no core-specific constants: it scales each core's own `*_DEFAULT_P_BASE` by `L2 / RISCV_L2_REFERENCE_KB`, both declared in that core's `param.h` block. Only `RISCV64_ZVL256B` opts in so far, with a base + reference tuned on the **SpaceMiT X60** — an empirical `P`/`Q` sweep showed its stock 128/128 blocking is already optimal for the 512 KB shared L2, so at 512 KB this reproduces the stock blocking exactly (**performance-neutral by construction**). The payoff is forward-looking: a part with a larger L2 gets a proportionally larger panel automatically, and another core opts in simply by declaring its own base + reference — no change to the arch-wide function. Every other RISC-V core is untouched (their `param.h` literals stand, and `blas_set_parameter()` is a no-op for them). Happy to adjust the scaling policy (e.g. discrete cache-size tiers like the LoongArch tables) if you'd prefer.

## Testing

- **SpaceMiT X60 (`RISCV64_ZVL256B`, RVV), static build** — `get_L2_size()` returns 512; `blas_set_parameter()` scales the ZVL256B base by 1 → effective blocking = stock (SGEMM 128/128/16384, DGEMM 64/128/8192); SGEMM throughput unchanged (no regression).
- **X60, `DYNAMIC_ARCH` build** — the `param.h` P macros resolve to the same literals as before (checked by preprocessing), so `kernel/setparam-ref.c`'s table init is unchanged; a dynamic build compiles cleanly (per-core `setparam_RISCV64_*.o` objects build with no errors).
- **SiFive U74 / VisionFive 2 (`rv64gc` scalar, GCC 13.3)** — the change compiles; `get_L2_size()` reads 2048 (the JH7110's 2 MB L2), confirming the sysfs detection generalizes. As a generality check, opting a second core in (the generic core) confirmed `blas_set_parameter()` scales that core's **own** base — `dgemm_p` 128→512 from the generic base, not the X60's 64 — i.e. the function is genuinely per-core. That test also showed the plain total-L2 scale can overshoot a large *shared* cache (`sa≈480 KiB` vs the 512 KiB/core share → 4-core DGEMM 3.12 vs 3.43 GF), which is why only ZVL256B opts in and why the scaling policy is called out as adjustable above.

Non-RISC-V builds are unaffected — every change is guarded by `ARCH_RISCV64`.
