### PR TITLE
Fix non-SVE ARM64 potentially using non-zeroed register in SDOT/DDOT accumulation

### DIFF
--- a/kernel/arm64/dot_kernel_asimd.c
+++ b/kernel/arm64/dot_kernel_asimd.c
@@ -262,16 +262,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static RETURN_TYPE dot_kernel_asimd(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 {
-#ifndef DOUBLE
-    volatile
-#endif
+
     RETURN_TYPE  dot = 0.0;
 	BLASLONG j = 0;
 
 	__asm__ __volatile__ (
 	"	fmov	"OUT", "REG0"			\n"
+	"	fmov	d0, xzr				\n"
 	"	fmov	d1, xzr				\n"
-	"	fmov	d2, xzr				\n"
+    "	fmov	d2, xzr				\n"
 	"	fmov	d3, xzr				\n"
 	"	fmov	d4, xzr				\n"
 	"	fmov	d5, xzr				\n"
@@ -342,7 +341,10 @@ static RETURN_TYPE dot_kernel_asimd(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT 
           [J_]    "r"   (j)
 	: "cc",
 	  "memory",
-	  "d1", "d2", "d3", "d4", "d5", "d6", "d7"
+	  "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+	  "v16", "v17", "v18", "v19", "v20", "v21", "v22",
+	  "v23", "v24", "v25", "v26", "v27", "v28", "v29",
+	  "v30", "v31"
 	);
 
 	return dot;

--- a/utest/test_dsdot.c
+++ b/utest/test_dsdot.c
@@ -53,7 +53,7 @@ CTEST(sdot,sdot_n_1)
 {
     static float x[64], y[64];
     for (int i = 0; i < 64; i++) { x[i] = 1.0f; y[i] = 1.0f; }
-    int n = 64, inc = 1;
+    blasint n = 64, inc = 1;
     float junk[4] = {1e6f, 1e6f, 1e6f, 1e6f};
     __asm__ volatile("ld1 {v0.4s}, [%0]" :: "r"(junk) : "v0");
     float r = BLASFUNC(sdot)(&n, x, &inc, y, &inc);
@@ -65,7 +65,7 @@ CTEST(ddot,ddot_n_1)
 {
     static double x[64], y[64];
     for (int i = 0; i < 64; i++) { x[i] = 1.0f; y[i] = 1.0f; }
-    int n = 64, inc = 1;
+    blasint n = 64, inc = 1;
     double junk[4] = {1e6f, 1e6f, 1e6f, 1e6f};
     __asm__ volatile("ld1 {v0.4s}, [%0]" :: "r"(junk) : "v0");
     double r = BLASFUNC(ddot)(&n, x, &inc, y, &inc);

--- a/utest/test_dsdot.c
+++ b/utest/test_dsdot.c
@@ -48,6 +48,7 @@ CTEST(dsdot,dsdot_n_1)
 
 }
 #endif
+#ifdef ARMV8
 #if defined(BUILD_SINGLE)
 CTEST(sdot,sdot_n_1)
 {
@@ -71,4 +72,5 @@ CTEST(ddot,ddot_n_1)
     double r = BLASFUNC(ddot)(&n, x, &inc, y, &inc);
     ASSERT_DBL_NEAR_TOL(64.,r, DOUBLE_EPS);
 }
+#endif
 #endif

--- a/utest/test_dsdot.c
+++ b/utest/test_dsdot.c
@@ -48,3 +48,27 @@ CTEST(dsdot,dsdot_n_1)
 
 }
 #endif
+#if defined(BUILD_SINGLE)
+CTEST(sdot,sdot_n_1)
+{
+    static float x[64], y[64];
+    for (int i = 0; i < 64; i++) { x[i] = 1.0f; y[i] = 1.0f; }
+    int n = 64, inc = 1;
+    float junk[4] = {1e6f, 1e6f, 1e6f, 1e6f};
+    __asm__ volatile("ld1 {v0.4s}, [%0]" :: "r"(junk) : "v0");
+    float r = BLASFUNC(sdot)(&n, x, &inc, y, &inc);
+    ASSERT_DBL_NEAR_TOL(64.,r, DOUBLE_EPS);
+}
+#endif
+#if defined(BUILD_DOUBLE)
+CTEST(ddot,ddot_n_1)
+{
+    static double x[64], y[64];
+    for (int i = 0; i < 64; i++) { x[i] = 1.0f; y[i] = 1.0f; }
+    int n = 64, inc = 1;
+    double junk[4] = {1e6f, 1e6f, 1e6f, 1e6f};
+    __asm__ volatile("ld1 {v0.4s}, [%0]" :: "r"(junk) : "v0");
+    double r = BLASFUNC(ddot)(&n, x, &inc, y, &inc);
+    ASSERT_DBL_NEAR_TOL(64.,r, DOUBLE_EPS);
+}
+#endif


### PR DESCRIPTION
fixes #5917 affecting Ampere One, Apple M, Neoverse N1/N2/V2 and ThunderX2T99