### PR TITLE
Mark temporaries as volatile to avoid SIGBUS in multithreaded builds with gcc15+ on 32bit FreeBSD/x86

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -18,6 +18,10 @@ HOSTARCH := $(shell uname -m)
 ifeq ($(HOSTARCH), amd64)
 HOSTARCH=x86_64
 endif
+ifeq ($(HOSTARCH), i386)
+HOSTARCH=x86
+override BINARY=32
+endif
 
 # Catch conflicting usage of ARCH in some BSD environments
 ifeq ($(ARCH), amd64)

--- a/driver/level2/tpmv_thread.c
+++ b/driver/level2/tpmv_thread.c
@@ -71,7 +71,7 @@
 
 static int tpmv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *dummy1, FLOAT *buffer, BLASLONG pos){
 
-  FLOAT *a, *x, *y;
+  volatile FLOAT *a, *x, *y;
 
   BLASLONG incx;
   BLASLONG m_from, m_to;

--- a/driver/level3/syr2k_kernel.c
+++ b/driver/level3/syr2k_kernel.c
@@ -47,7 +47,7 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r,
 
   BLASLONG i, j;
   BLASLONG loop;
-  FLOAT subbuffer[GEMM_UNROLL_MN * GEMM_UNROLL_MN * COMPSIZE];
+  volatile FLOAT subbuffer[GEMM_UNROLL_MN * GEMM_UNROLL_MN * COMPSIZE];
 
   if (m + offset < 0) {
 #ifndef LOWER

--- a/kernel/generic/trmm_lncopy_4.c
+++ b/kernel/generic/trmm_lncopy_4.c
@@ -44,9 +44,9 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
   BLASLONG i, js;
   BLASLONG X;
 
-  FLOAT data01, data02, data03, data04, data05, data06, data07, data08;
-  FLOAT data09, data10, data11, data12, data13, data14, data15, data16;
-  FLOAT *ao1, *ao2, *ao3, *ao4;
+  volatile FLOAT data01, data02, data03, data04, data05, data06, data07, data08;
+  volatile FLOAT data09, data10, data11, data12, data13, data14, data15, data16;
+  volatile FLOAT *ao1, *ao2, *ao3, *ao4;
 
   js = (n >> 2);
 

--- a/kernel/generic/trmm_ltcopy_4.c
+++ b/kernel/generic/trmm_ltcopy_4.c
@@ -44,9 +44,9 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
   BLASLONG i, js;
   BLASLONG X;
 
-  FLOAT data01, data02, data03, data04, data05, data06, data07, data08;
-  FLOAT data09, data10, data11, data12, data13, data14, data15, data16;
-  FLOAT *ao1, *ao2, *ao3, *ao4;
+  volatile FLOAT data01, data02, data03, data04, data05, data06, data07, data08;
+  volatile FLOAT data09, data10, data11, data12, data13, data14, data15, data16;
+  volatile FLOAT *ao1, *ao2, *ao3, *ao4;
 
   js = (n >> 2);
 

--- a/kernel/generic/trmm_utcopy_4.c
+++ b/kernel/generic/trmm_utcopy_4.c
@@ -44,9 +44,9 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
   BLASLONG i, js;
   BLASLONG X;
 
-  FLOAT data01, data02, data03, data04, data05, data06, data07, data08;
-  FLOAT data09, data10, data11, data12, data13, data14, data15, data16;
-  FLOAT *ao1, *ao2, *ao3, *ao4;
+  volatile FLOAT data01, data02, data03, data04, data05, data06, data07, data08;
+  volatile FLOAT data09, data10, data11, data12, data13, data14, data15, data16;
+  volatile FLOAT *ao1, *ao2, *ao3, *ao4;
 
   js = (n >> 2);
 


### PR DESCRIPTION
fixes #5905 (as far as I could reproduce issues)