### PR TITLE
loongarch64: fix segfaults in copy kernels and adjust dsyrk block size

### DIFF
--- a/driver/level3/level3_syrk_threaded.c
+++ b/driver/level3/level3_syrk_threaded.c
@@ -37,6 +37,11 @@
 /* or implied, of The University of Texas at Austin.                 */
 /*********************************************************************/
 
+#if defined(__loongarch__) && defined(LA464) && defined(DOUBLE)
+#undef GEMM_P
+#define GEMM_P 96
+#endif
+
 #ifndef CACHE_LINE_SIZE
 #define CACHE_LINE_SIZE 8
 #endif

--- a/kernel/loongarch64/dgemm_ncopy_4_lsx.S
+++ b/kernel/loongarch64/dgemm_ncopy_4_lsx.S
@@ -172,6 +172,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     blt        ZERO, I,    .L_2II1
 .L_N1:
     move      S1,    TS
+    andi      J,     N,   0x01
+    beq       ZERO,  J,   .L_N0
     beq       ZERO,  M,   .L_N0
 .L_M1:
     fld.d     F0,    S1,  0x00

--- a/kernel/loongarch64/sgemm_ncopy_16_lasx.S
+++ b/kernel/loongarch64/sgemm_ncopy_16_lasx.S
@@ -453,6 +453,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .align 5
 .L_N1:
     move      S1,    TS
+    andi      J,     N,   0x01
+    beq       ZERO,  J,   .L_N0
     beq       ZERO,  M,   .L_N0
 .L_N1_M1:
     fld.s       F0,    S1,  0x00

--- a/kernel/loongarch64/sgemm_ncopy_8_lasx.S
+++ b/kernel/loongarch64/sgemm_ncopy_8_lasx.S
@@ -288,7 +288,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .align 5
 .L_N1:
     move      S1,    TS
+    andi      J,     N,   0x01
+    beq       ZERO,  J,   .L_N0
     beq       ZERO,  M,   .L_N0
+
 .L_N1_M1:
     fld.s       F0,    S1,  0x00
     PTR_ADDI    S1,    S1,  0x04


### PR DESCRIPTION
On LA464, `dsyrk` produces incorrect results with specific block dimension combinations (e.g., 80×16), which causes `dcholesky` and `dpotrf` to fail on positive-definite matrices.

Reduce `GEMM_P` from 112 to 96 for LoongArch64 LA464 double-precision builds, so the blocking logic avoids generating the problematic size.

The following minimal C program was used to pinpoint the issue:

```c
// test_dsyrk.c
#include <stdio.h>
#include <cblas.h>
#include <stdlib.h>

#define N 194
int main(){
    double *A = malloc(N*N*sizeof(double));
    double *B = malloc(N*N*sizeof(double));
    for(int j=0;j<N;j++){
        for(int i=0;i<j;i++) A[i + j*N] = (double)rand()/RAND_MAX - 0.5;
        A[j + j*N] = (double)rand()/RAND_MAX + 8.0;
        for(int i=j+1;i<N;i++) A[i + j*N] = 0.0;
    }

    double alpha = 1.0, beta = 0.0;
    cblas_dsyrk(CblasColMajor, CblasLower, CblasNoTrans, N, N, alpha, A, N, beta, B, N);

    for (int i = 0; i < N; i++) 
        printf("B[%d][%d] = %g\n", i, i, B[i + i*N]);

    free(A); free(B);
    return 0;
}
```

Compile and run:

```bash
gcc test_dsyrk.c -o testd_syrk -I. -L. -lopenblas -lpthread -lm
./test_dsyrk
```

**After fix**: all diagonal elements remain positive as expected.