### PR TITLE
Fix pointer comparison in laed3.c threading threshold

### DIFF
--- a/interface/lapack/laed3.c
+++ b/interface/lapack/laed3.c
@@ -74,7 +74,7 @@ int NAME(blasint *k, blasint *n, blasint *n1, FLOAT *d,
 
 #ifdef SMP
   int nthreads = 1;
-  if (n >= 64) nthreads = num_cpu_avail(4);
+  if (nval >= 64) nthreads = num_cpu_avail(4);
 
   if (nthreads == 1) {
 #endif


### PR DESCRIPTION
## Bug: Pointer comparison instead of value comparison in `laed3.c` threading threshold

**File:** `interface/lapack/laed3.c`

**Line:** 76

**Current code:**
```c
if (n >= 64) nthreads = num_cpu_avail(4);
```

**Expected:**
```c
if (nval >= 64) nthreads = num_cpu_avail(4);
```