### PR TITLE
Fix workspace size in ReLAPACK sytrf/hetrf

### DIFF
--- a/relapack/src/chetrf.c
+++ b/relapack/src/chetrf.c
@@ -19,8 +19,8 @@ void RELAPACK_chetrf(
     float *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (CREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * CREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/chetrf_rook.c
+++ b/relapack/src/chetrf_rook.c
@@ -19,8 +19,8 @@ void RELAPACK_chetrf_rook(
     float *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (CREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * CREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/csytrf.c
+++ b/relapack/src/csytrf.c
@@ -19,8 +19,8 @@ void RELAPACK_csytrf(
     float *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (CREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * CREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/csytrf_rook.c
+++ b/relapack/src/csytrf_rook.c
@@ -19,8 +19,8 @@ void RELAPACK_csytrf_rook(
     float *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (CREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * CREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/dsytrf.c
+++ b/relapack/src/dsytrf.c
@@ -19,8 +19,8 @@ void RELAPACK_dsytrf(
     double *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (DREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * DREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/dsytrf_rook.c
+++ b/relapack/src/dsytrf_rook.c
@@ -19,8 +19,8 @@ void RELAPACK_dsytrf_rook(
     double *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (DREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * DREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/ssytrf.c
+++ b/relapack/src/ssytrf.c
@@ -18,8 +18,8 @@ void RELAPACK_ssytrf(
     float *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (SREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * SREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/ssytrf_rook.c
+++ b/relapack/src/ssytrf_rook.c
@@ -19,8 +19,8 @@ void RELAPACK_ssytrf_rook(
     float *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (SREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * SREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/zhetrf.c
+++ b/relapack/src/zhetrf.c
@@ -19,8 +19,8 @@ void RELAPACK_zhetrf(
     double *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (ZREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * ZREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/zhetrf_rook.c
+++ b/relapack/src/zhetrf_rook.c
@@ -19,8 +19,8 @@ void RELAPACK_zhetrf_rook(
     double *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (ZREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * ZREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/zsytrf.c
+++ b/relapack/src/zsytrf.c
@@ -19,8 +19,8 @@ void RELAPACK_zsytrf(
     double *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (ZREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * ZREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;

--- a/relapack/src/zsytrf_rook.c
+++ b/relapack/src/zsytrf_rook.c
@@ -19,8 +19,8 @@ void RELAPACK_zsytrf_rook(
     double *Work, const blasint *lWork, blasint *info
 ) {
 
-    // Required work size
-    const blasint cleanlWork = *n * (*n / 2);
+    // Required work size (ZREC_SPLIT rounds up)
+    const blasint cleanlWork = *n * ZREC_SPLIT(*n);
     blasint minlWork = cleanlWork;
 #if XSYTRF_ALLOW_MALLOC
     minlWork = 1;


### PR DESCRIPTION
The `?sytrf`/`?hetrf` routines size their workspace as `n*(n/2)` and report that from the `lWork = -1` query, but the top level recursion addresses `Work` as an `n` by `xREC_SPLIT(n)` matrix with leading dimension `n`. `xREC_SPLIT` rounds up, so whenever `xREC_SPLIT(n) > n/2` the routine writes past the end of the buffer it asked for — silently wrong factorization and a corrupted heap.

For `zsytrf`, `ZREC_SPLIT(500) = 252` against the 250 columns the buffer holds.

Repro: build with `BUILD_RELAPACK=1 RELAPACK_REPLACE=1`, query `lWork`, allocate exactly that, call `zsytrf`. Before this patch 114 of 241 sizes in `[64,1024]` return garbage; sweeping every `n` in `[100,600]` aborts on heap corruption. After, a workspace-query/factorize/solve residual check over 12 routines x every `n` in `[64,400]` passes 4044/4044.

Sizes the workspace with the same `xREC_SPLIT` the recursion uses. Affects all 12 variants.