### PR TITLE
LoongArch: Fix DSDOT accumulator initialization

### DIFF
--- a/.github/workflows/loongarch64.yml
+++ b/.github/workflows/loongarch64.yml
@@ -83,12 +83,6 @@ jobs:
             /usr/local/bin/qemu-loongarch64-static
           qemu-loongarch64-static --version
 
-      - name: Disable utest dsdot:dsdot_n_1
-        run: |
-          echo -n > utest/test_dsdot.c
-          echo "Due to the current version of qemu causing utest cases to fail,"
-          echo "the utest dsdot:dsdot_n_1 have been temporarily disabled."
-
       - name: Build OpenBLAS
         run: |
           make CC='ccache ${{ matrix.triple }}-gcc-14 -static' FC='ccache ${{ matrix.triple }}-gfortran-14 -static' \

--- a/.github/workflows/loongarch64_clang.yml
+++ b/.github/workflows/loongarch64_clang.yml
@@ -92,12 +92,6 @@ jobs:
           echo "compression = true" >> ~/.ccache/ccache.conf
           ccache -s
 
-      - name: Disable utest dsdot:dsdot_n_1
-        run: |
-          echo -n > utest/test_dsdot.c
-          echo "Due to the qemu versions 7.2 causing utest cases to fail,"
-          echo "the utest dsdot:dsdot_n_1 have been temporarily disabled."
-
       - name: Build OpenBLAS
         run: make CC='ccache clang --target=loongarch64-linux-gnu --sysroot=/opt/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.3/loongarch64-linux-gnu/sysroot/ -static' FC='ccache loongarch64-linux-gnu-gfortran -static' HOSTCC='ccache clang' CROSS_SUFFIX=llvm-  NO_SHARED=1 ${{ matrix.opts }} -j$(nproc)
 

--- a/kernel/loongarch64/dot.S
+++ b/kernel/loongarch64/dot.S
@@ -54,8 +54,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    LDINT   INCY,  0(INCY)
 #endif
 
-   MTC  s1, $r0
-   MTC  s2, $r0
+   movgr2fr.d  s1, $r0
+   movgr2fr.d  s2, $r0
    slli.d  INCX, INCX, BASE_SHIFT
    li.d  TEMP, SIZE
    slli.d INCY, INCY, BASE_SHIFT


### PR DESCRIPTION
- Zero the full 64-bit DSDOT accumulators before double-precision operations.
- Re-enable the DSDOT unit test in the GCC and Clang LoongArch CI workflows.