### PR TITLE
Fix: CBLAS order handling in `gemm_batch_strided` for column-major layout

### DIFF
--- a/interface/gemm_batch_strided.c
+++ b/interface/gemm_batch_strided.c
@@ -229,13 +229,16 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE transa, enum CBLAS_TRANS
     group_transb = -1;
     info   = 0;
    
-#if defined(CBLAS) 
+#if defined(CBLAS)
     if (order == CblasColMajor) {
       group_m = m;
       group_n = n;
       group_k = k;
 
-      
+      group_lda = lda;
+      group_ldb = ldb;
+      group_ldc = ldc;
+
       if (transa == CblasNoTrans)     group_transa = 0;
       if (transa == CblasTrans)       group_transa = 1;
 #ifndef COMPLEX


### PR DESCRIPTION
Hi devs!

This PR will fix calling `gemm_batch_strided` in CBLAS with column-major layout.
Current code will not set batched-group stride (`group_lda/b/c`) if column-major (where they were setted if row-major, refer to [this code]( https://github.com/OpenMathLib/OpenBLAS/blob/e0cabe9b5911c58425e3f33e65caa7c01e60393e/interface/gemm_batch_strided.c#L279-L281)). Consequently, the program will raise error like this:
```
 ** On entry to DGEMM_BATCH_STRIDED  parameter number  8 had an illegal value
```
This is due to the `group_lda/b/c` initialized to zero (but not set proper value later), causing [this code](https://github.com/OpenMathLib/OpenBLAS/blob/e0cabe9b5911c58425e3f33e65caa7c01e60393e/interface/gemm_batch_strided.c#L264-L266) returns error code 8.

The fix is strightford: initialize `group_lda/b/c` like what row-major's code does.

------

This was found when I'm developing rust's numpy-like toolkit [RSTSR](https://github.com/RESTGroup/rstsr), when trying to use batched gemm for broadcasted matrix-multiplication implementation with OpenBLAS backend.
This bug was originally found in AI code agent session (Claude Code with model GLM-5.3).