### PR TITLE
Fix: Small matrix `gemm_batch` with DYNAMIC_ARCH

### DIFF
--- a/interface/gemm_batch.c
+++ b/interface/gemm_batch.c
@@ -353,18 +353,18 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE *  transa_array, enum CB
 #if !defined(COMPLEX)
       if(*(FLOAT *)(group_beta) == 0.0){
 	group_mode=mode | BLAS_SMALL_B0_OPT;
-	group_small_matrix_opt_routine=(void *)(gemm_small_kernel_b0[(group_transb<<2)|group_transa]);
+	group_small_matrix_opt_routine=SMALL_KERNEL_ADDR(gemm_small_kernel_b0, ((group_transb<<2)|group_transa));
       }else{
 	group_mode=mode | BLAS_SMALL_OPT;
-	group_small_matrix_opt_routine=(void *)(gemm_small_kernel[(group_transb<<2)|group_transa]);
+	group_small_matrix_opt_routine=SMALL_KERNEL_ADDR(gemm_small_kernel, ((group_transb<<2)|group_transa));
       }
 #else
       if(((FLOAT *)(group_beta))[0] == 0.0 && ((FLOAT *)(group_beta))[1] == 0.0){
 	group_mode=mode | BLAS_SMALL_B0_OPT;
-	group_small_matrix_opt_routine=(void *)(zgemm_small_kernel_b0[(group_transb<<2)|group_transa]);
+	group_small_matrix_opt_routine=SMALL_KERNEL_ADDR(zgemm_small_kernel_b0, ((group_transb<<2)|group_transa));
       }else{
 	group_mode=mode | BLAS_SMALL_OPT;
-	group_small_matrix_opt_routine=(void *)(zgemm_small_kernel[(group_transb<<2)|group_transa]);
+	group_small_matrix_opt_routine=SMALL_KERNEL_ADDR(zgemm_small_kernel, ((group_transb<<2)|group_transa));
       }
 
 #endif


### PR DESCRIPTION
Hi devs!

This PR will fix segfault, when batched gemm on small matrices with DYNAMIC_ARCH compiled OpenBLAS.

DYNAMIC_ARCH seems to require `SMALL_KERNEL_ADDR` to resolve dispatched small kernel.
For non-DYNAMIC_ARCH, since there is only one table and not required to be resolved, so the current code works.

------

This was found when I'm developing rust's numpy-like toolkit [RSTSR](https://github.com/RESTGroup/rstsr), when trying to use batched gemm for broadcasted matrix-multiplication implementation with OpenBLAS backend.
This bug was originally found in AI code agent session (Claude Code with model GLM-5.3).