### PR TITLE
C_LAPACK: take the float format from <float.h> in dlamch/slamch

### DIFF
--- a/lapack-netlib/INSTALL/dlamch.c
+++ b/lapack-netlib/INSTALL/dlamch.c
@@ -1,3 +1,4 @@
+#include <float.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -354,29 +355,13 @@ static doublereal c_b32 = 0.;
 /*  ===================================================================== */
 doublereal dlamch_(char *cmach)
 {
-    /* Initialized data */
-
-    static logical first = TRUE_;
-
     /* System generated locals */
-    integer i__1;
     doublereal ret_val;
 
     /* Local variables */
-    static doublereal base;
-    integer beta;
-    static doublereal emin, prec, emax;
-    integer imin, imax;
-    logical lrnd;
-    static doublereal rmin, rmax, t;
     doublereal rmach;
     extern logical lsame_(char *, char *);
-    doublereal small;
-    static doublereal sfmin;
-    extern /* Subroutine */ int dlamc2_(integer *, integer *, logical *, 
-	    doublereal *, integer *, doublereal *, integer *, doublereal *);
-    integer it;
-    static doublereal rnd, eps;
+    doublereal small, sfmin, eps;
 
 
 /*  -- LAPACK auxiliary routine (version 3.7.0) -- */
@@ -385,24 +370,23 @@ doublereal dlamch_(char *cmach)
 /*     April 2012 */
 
 
-    if (first) {
-	dlamc2_(&beta, &it, &lrnd, &eps, &imin, &rmin, &imax, &rmax);
-	base = (doublereal) beta;
-	t = (doublereal) it;
-	if (lrnd) {
-	    rnd = 1.;
-	    i__1 = 1 - it;
-	    eps = pow_di(&base, &i__1) / 2;
-	} else {
-	    rnd = 0.;
-	    i__1 = 1 - it;
-	    eps = pow_di(&base, &i__1);
-	}
-	prec = eps * base;
-	emin = (doublereal) imin;
-	emax = (doublereal) imax;
-	sfmin = rmin;
-	small = 1. / rmax;
+/*     The values below are those returned by the current dlamch.f, which */
+/*     obtains them from the Fortran 90 inquiry intrinsics.  They replace the */
+/*     dlamc1/dlamc2 probe of the deprecated dlamchf77.f, which measures the */
+/*     format at run time and is only correct if double intermediates are */
+/*     genuinely rounded to double.  That does not hold on x87: the probe */
+/*     measures the 80 bit register format instead, and dlamch then returns 0 */
+/*     for the safe minimum and +Inf for the overflow threshold.  Reading the */
+/*     constants also makes this routine thread safe, which the cached, */
+/*     probed version was not. */
+
+    eps = DBL_EPSILON * 0.5;
+
+    if (lsame_(cmach, "E")) {
+	rmach = eps;
+    } else if (lsame_(cmach, "S")) {
+	sfmin = DBL_MIN;
+	small = 1. / DBL_MAX;
 	if (small >= sfmin) {
 
 /*           Use SMALL plus a bit, to avoid the possibility of rounding */
@@ -410,32 +394,28 @@ doublereal dlamch_(char *cmach)
 
 	    sfmin = small * (eps + 1.);
 	}
-    }
-
-    if (lsame_(cmach, "E")) {
-	rmach = eps;
-    } else if (lsame_(cmach, "S")) {
 	rmach = sfmin;
     } else if (lsame_(cmach, "B")) {
-	rmach = base;
+	rmach = FLT_RADIX;
     } else if (lsame_(cmach, "P")) {
-	rmach = prec;
+	rmach = eps * FLT_RADIX;
     } else if (lsame_(cmach, "N")) {
-	rmach = t;
+	rmach = DBL_MANT_DIG;
     } else if (lsame_(cmach, "R")) {
-	rmach = rnd;
+	rmach = 1.;
     } else if (lsame_(cmach, "M")) {
-	rmach = emin;
+	rmach = DBL_MIN_EXP;
     } else if (lsame_(cmach, "U")) {
-	rmach = rmin;
+	rmach = DBL_MIN;
     } else if (lsame_(cmach, "L")) {
-	rmach = emax;
+	rmach = DBL_MAX_EXP;
     } else if (lsame_(cmach, "O")) {
-	rmach = rmax;
+	rmach = DBL_MAX;
+    } else {
+	rmach = 0.;
     }
 
     ret_val = rmach;
-    first = FALSE_;
     return ret_val;
 
 /*     End of DLAMCH */

--- a/lapack-netlib/INSTALL/slamch.c
+++ b/lapack-netlib/INSTALL/slamch.c
@@ -1,3 +1,4 @@
+#include <float.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -353,29 +354,13 @@ static real c_b32 = 0.f;
 /*  ===================================================================== */
 real slamch_(char *cmach)
 {
-    /* Initialized data */
-
-    static logical first = TRUE_;
-
     /* System generated locals */
-    integer i__1;
     real ret_val;
 
     /* Local variables */
-    static real base;
-    integer beta;
-    static real emin, prec, emax;
-    integer imin, imax;
-    logical lrnd;
-    static real rmin, rmax, t;
     real rmach;
     extern logical lsame_(char *, char *);
-    real small;
-    static real sfmin;
-    extern /* Subroutine */ int slamc2_(integer *, integer *, logical *, real 
-	    *, integer *, real *, integer *, real *);
-    integer it;
-    static real rnd, eps;
+    real small, sfmin, eps;
 
 
 /*  -- LAPACK auxiliary routine (version 3.7.0) -- */
@@ -384,24 +369,23 @@ real slamch_(char *cmach)
 /*     April 2012 */
 
 
-    if (first) {
-	slamc2_(&beta, &it, &lrnd, &eps, &imin, &rmin, &imax, &rmax);
-	base = (real) beta;
-	t = (real) it;
-	if (lrnd) {
-	    rnd = 1.f;
-	    i__1 = 1 - it;
-	    eps = pow_ri(&base, &i__1) / 2;
-	} else {
-	    rnd = 0.f;
-	    i__1 = 1 - it;
-	    eps = pow_ri(&base, &i__1);
-	}
-	prec = eps * base;
-	emin = (real) imin;
-	emax = (real) imax;
-	sfmin = rmin;
-	small = 1.f / rmax;
+/*     The values below are those returned by the current slamch.f, which */
+/*     obtains them from the Fortran 90 inquiry intrinsics.  They replace the */
+/*     slamc1/slamc2 probe of the deprecated slamchf77.f, which measures the */
+/*     format at run time and is only correct if intermediates are genuinely */
+/*     rounded to single.  That does not hold on x87: the probe measures the */
+/*     80 bit register format instead, and slamch then returns 0 for the safe */
+/*     minimum and +Inf for the overflow threshold.  Reading the constants */
+/*     also makes this routine thread safe, which the cached, probed version */
+/*     was not. */
+
+    eps = FLT_EPSILON * 0.5f;
+
+    if (lsame_(cmach, "E")) {
+	rmach = eps;
+    } else if (lsame_(cmach, "S")) {
+	sfmin = FLT_MIN;
+	small = 1.f / FLT_MAX;
 	if (small >= sfmin) {
 
 /*           Use SMALL plus a bit, to avoid the possibility of rounding */
@@ -409,32 +393,28 @@ real slamch_(char *cmach)
 
 	    sfmin = small * (eps + 1.f);
 	}
-    }
-
-    if (lsame_(cmach, "E")) {
-	rmach = eps;
-    } else if (lsame_(cmach, "S")) {
 	rmach = sfmin;
     } else if (lsame_(cmach, "B")) {
-	rmach = base;
+	rmach = FLT_RADIX;
     } else if (lsame_(cmach, "P")) {
-	rmach = prec;
+	rmach = eps * FLT_RADIX;
     } else if (lsame_(cmach, "N")) {
-	rmach = t;
+	rmach = FLT_MANT_DIG;
     } else if (lsame_(cmach, "R")) {
-	rmach = rnd;
+	rmach = 1.f;
     } else if (lsame_(cmach, "M")) {
-	rmach = emin;
+	rmach = FLT_MIN_EXP;
     } else if (lsame_(cmach, "U")) {
-	rmach = rmin;
+	rmach = FLT_MIN;
     } else if (lsame_(cmach, "L")) {
-	rmach = emax;
+	rmach = FLT_MAX_EXP;
     } else if (lsame_(cmach, "O")) {
-	rmach = rmax;
+	rmach = FLT_MAX;
+    } else {
+	rmach = 0.f;
     }
 
     ret_val = rmach;
-    first = FALSE_;
     return ret_val;
 
 /*     End of SLAMCH */


### PR DESCRIPTION
`lapack-netlib/INSTALL/dlamch.c` and `slamch.c` are f2c translations of the deprecated
`dlamchf77.f`/`slamchf77.f`, which determine the floating point format at run time by
probing in `dlamc1`/`dlamc2`. The current `dlamch.f` uses the Fortran 90 inquiry
intrinsics instead, but f2c cannot translate those, so the C LAPACK selected by
`NOFORTRAN=1` was left with the older probing implementation.

The probe is only correct if double intermediates are genuinely rounded to double. That
does not hold on x87, where they stay in 80 bit registers and the probe measures the
register format instead of the storage format.

### This affects stock 32 bit builds, not just unusual ones

`Makefile.x86` adds `-msse2` but never `-mfpmath=sse`, and on 32 bit x86 `-msse2` enables
the instructions without changing the FP math default away from 387. With gcc 16.1.0:

```
-msse2                 ->  fldl / fmull / faddl     (x87)
-msse2 -mfpmath=sse    ->  movsd / mulsd / addsd    (SSE)
```

So a stock 32 bit `NOFORTRAN=1` build compiles `dlamch.c` with x87 double arithmetic,
which is exactly the condition that breaks the probe.

### Reproduction

Linking `INSTALL/dlamch.c` and `INSTALL/slamch.c` from current `develop` against a test
program that compares every `cmach` against `<float.h>`, built with the stock 32 bit
flags `-O2 -msse2`, **16 of the 20 constants are wrong**:

| | before | expected |
|---|---|---|
| `dlamch('E')` | 5.4210108624275222e-20 | 1.1102230246251565e-16 |
| `dlamch('S')` | **0** | 2.2250738585072014e-308 |
| `dlamch('N')` | 64 | 53 |
| `dlamch('M')` | -16381 | -1021 |
| `dlamch('L')` | 16385 | 1024 |
| `dlamch('O')` | **inf** | 1.7976931348623157e+308 |
| `slamch('S')` | **0** | 1.1754943508222875e-38 |
| `slamch('N')` | 64 | 24 |
| `slamch('O')` | **inf** | 3.4028234663852886e+38 |

Note that `slamch` reports the 80 bit format too, and that the mantissa width follows the
caller's x87 precision control bits rather than being a property of the type at all.

It is not always a silent wrong answer. With the x87 control word `0x1332` (extended
precision, overflow unmasked, which is what Delphi sets) the unpatched code terminates
with `STATUS_FLOAT_OVERFLOW` (`0xC0000091`) inside `dlamch` itself.

Where the values are merely wrong rather than fatal, everything that scales by them is
wrong. The first symptom we saw was `dsbevx`, which computes

```
safmin = dlamch('S')
eps    = dlamch('P')
smlnum = safmin / eps
bignum = 1 / smlnum
```

so a zero safe minimum makes `smlnum` zero and the next line divides by zero. Callers that
unmask the divide by zero exception get a hard failure there; callers that do not get
whatever the wrong scaling produces.

With this patch all 20 constants are correct, at the default control word and at `0x1332`
and `0x037F`.

x86_64 is not affected by this part, since `-mfpmath=sse` is the default there and the
probe measures the right format. I have verified that separately.

### Two further problems fixed at the same time, on all architectures

These are not x87 specific and apply to every `NOFORTRAN=1` build, x86_64 included:

- `rmach` was left uninitialised when `cmach` matched nothing, where `dlamch.f` returns
  zero.
- The cached `static` results made both routines unsafe to call concurrently on first
  use.

### What the patch does

Replaces the probe with the `<float.h>` constants, mirroring the values the current
`dlamch.f` and `slamch.f` return via the F90 intrinsics.

`dlamc1`-`dlamc5` and `slamc1`-`slamc5` are deliberately left in place. They become
unreachable from `dlamch`/`slamch`, but `dlamc3`/`slamc3` have callers of their own in
`dlaed3`, `dlaed9`, `dlals0`, `dlasd3`, `dlasd8` and their complex equivalents, where they
serve as optimiser barriers. Happy to remove the genuinely dead `dlamc1/2/4/5` in a
follow-up if you would prefer.

Regenerating these files from the modern `dlamch.f` is not an option, since f2c cannot
translate the F90 inquiry intrinsics — which is how the C path came to be stuck on the
deprecated version in the first place.

These two `.c` files are OpenBLAS's own artifacts, added in #3539 and hand maintained
since (#3605, `4041b7fb4`); Reference-LAPACK ships only the `.f`, and its `dlamch.f` is
already correct. So this does not need to go to Reference-LAPACK, and will not be
clobbered by a future re-sync.

`gcc -Wall` reports no new warnings; the patch removes one of the five that current
`develop` produces for this file.

This has been running in production in our fork since 0.3.34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
