### PR TITLE
Ensure a safe distance between work arrays in the buffer of single-threaded POTRF

### DIFF
--- a/lapack/potrf/potrf_L_single.c
+++ b/lapack/potrf/potrf_L_single.c
@@ -68,7 +68,7 @@ static FLOAT dm1 = -1.;
 #define GEMM_PQ  MAX(GEMM_P, GEMM_Q)
 
 //leave some space for GEMM_ALIGN in sb2
-#define REAL_GEMM_R (GEMM_R - 2*GEMM_PQ)
+#define REAL_GEMM_R (MAX(GEMM_R, GEMM_PQ + 96) - GEMM_PQ)
 
 #if 0
 #define SHARED_ARRAY

--- a/lapack/potrf/potrf_U_single.c
+++ b/lapack/potrf/potrf_U_single.c
@@ -66,7 +66,7 @@ static FLOAT dm1 = -1.;
 #endif
 
 #define GEMM_PQ  MAX(GEMM_P, GEMM_Q)
-#define REAL_GEMM_R (GEMM_R - GEMM_PQ)
+#define REAL_GEMM_R (MAX(GEMM_R, GEMM_PQ + 96) - GEMM_PQ)
 
 #if 0
 #define SHARED_ARRAY


### PR DESCRIPTION
fixes #5981 as suggested by HecaiYuan there, improving on my previous fix for the "U" case in #5612 by no longer constraining GEMM_R for Loongson (or any other) target