### PR TITLE
Revert "Use QR for bidiagonal SVD with vectors in ?BDSDC (Reference-LAPACK PR 1300)"

### DIFF
--- a/lapack-netlib/SRC/dbdsdc.f
+++ b/lapack-netlib/SRC/dbdsdc.f
@@ -5,6 +5,7 @@
 * Online html documentation available at
 *            http://www.netlib.org/lapack/explore-html/
 *
+*> \htmlonly
 *> Download DBDSDC + dependencies
 *> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/dbdsdc.f">
 *> [TGZ]</a>
@@ -12,6 +13,7 @@
 *> [ZIP]</a>
 *> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/dbdsdc.f">
 *> [TXT]</a>
+*> \endhtmlonly
 *
 *  Definition:
 *  ===========
@@ -182,7 +184,7 @@
 *> \author Univ. of Colorado Denver
 *> \author NAG Ltd.
 *
-*> \ingroup bdsdc
+*> \ingroup auxOTHERcomputational
 *
 *> \par Contributors:
 *  ==================
@@ -191,10 +193,8 @@
 *>     California at Berkeley, USA
 *>
 *  =====================================================================
-      SUBROUTINE DBDSDC( UPLO, COMPQ, N, D, E, U, LDU, VT, LDVT, Q,
-     $                   IQ,
+      SUBROUTINE DBDSDC( UPLO, COMPQ, N, D, E, U, LDU, VT, LDVT, Q, IQ,
      $                   WORK, IWORK, INFO )
-      IMPLICIT NONE
 *
 *  -- LAPACK computational routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -233,8 +233,7 @@
       EXTERNAL           LSAME, ILAENV, DLAMCH, DLANST
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           DCOPY, DLARTG, DLASCL, DLASD0, DLASDA,
-     $                   DLASDQ,
+      EXTERNAL           DCOPY, DLARTG, DLASCL, DLASD0, DLASDA, DLASDQ,
      $                   DLASET, DLASR, DSWAP, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
@@ -341,17 +340,14 @@
          IF( ICOMPQ.EQ.2 ) THEN
             CALL DLASET( 'A', N, N, ZERO, ONE, U, LDU )
             CALL DLASET( 'A', N, N, ZERO, ONE, VT, LDVT )
-            CALL DLASDQ( 'U', 0, N, N, N, 0, D, E, VT, LDVT, U, LDU,
-     $                   U,
+            CALL DLASDQ( 'U', 0, N, N, N, 0, D, E, VT, LDVT, U, LDU, U,
      $                   LDU, WORK( WSTART ), INFO )
          ELSE IF( ICOMPQ.EQ.1 ) THEN
             IU = 1
             IVT = IU + N
-            CALL DLASET( 'A', N, N, ZERO, ONE,
-     $                   Q( IU+( QSTART-1 )*N ),
+            CALL DLASET( 'A', N, N, ZERO, ONE, Q( IU+( QSTART-1 )*N ),
      $                   N )
-            CALL DLASET( 'A', N, N, ZERO, ONE,
-     $                   Q( IVT+( QSTART-1 )*N ),
+            CALL DLASET( 'A', N, N, ZERO, ONE, Q( IVT+( QSTART-1 )*N ),
      $                   N )
             CALL DLASDQ( 'U', 0, N, N, N, 0, D, E,
      $                   Q( IVT+( QSTART-1 )*N ), N,
@@ -509,8 +505,7 @@
 *     which rotated B to be upper bidiagonal
 *
       IF( ( IUPLO.EQ.2 ) .AND. ( ICOMPQ.EQ.2 ) )
-     $   CALL DLASR( 'L', 'V', 'B', N, N, WORK( 1 ), WORK( N ), U,
-     $               LDU )
+     $   CALL DLASR( 'L', 'V', 'B', N, N, WORK( 1 ), WORK( N ), U, LDU )
 *
       RETURN
 *

--- a/lapack-netlib/SRC/sbdsdc.f
+++ b/lapack-netlib/SRC/sbdsdc.f
@@ -5,6 +5,7 @@
 * Online html documentation available at
 *            http://www.netlib.org/lapack/explore-html/
 *
+*> \htmlonly
 *> Download SBDSDC + dependencies
 *> <a href="http://www.netlib.org/cgi-bin/netlibfiles.tgz?format=tgz&filename=/lapack/lapack_routine/sbdsdc.f">
 *> [TGZ]</a>
@@ -12,6 +13,7 @@
 *> [ZIP]</a>
 *> <a href="http://www.netlib.org/cgi-bin/netlibfiles.txt?format=txt&filename=/lapack/lapack_routine/sbdsdc.f">
 *> [TXT]</a>
+*> \endhtmlonly
 *
 *  Definition:
 *  ===========
@@ -182,7 +184,7 @@
 *> \author Univ. of Colorado Denver
 *> \author NAG Ltd.
 *
-*> \ingroup bdsdc
+*> \ingroup auxOTHERcomputational
 *
 *> \par Contributors:
 *  ==================
@@ -191,10 +193,8 @@
 *>     California at Berkeley, USA
 *>
 *  =====================================================================
-      SUBROUTINE SBDSDC( UPLO, COMPQ, N, D, E, U, LDU, VT, LDVT, Q,
-     $                   IQ,
+      SUBROUTINE SBDSDC( UPLO, COMPQ, N, D, E, U, LDU, VT, LDVT, Q, IQ,
      $                   WORK, IWORK, INFO )
-      IMPLICIT NONE
 *
 *  -- LAPACK computational routine --
 *  -- LAPACK is a software package provided by Univ. of Tennessee,    --
@@ -233,8 +233,7 @@
       EXTERNAL           SLAMCH, SLANST, ILAENV, LSAME
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           SCOPY, SLARTG, SLASCL, SLASD0, SLASDA,
-     $                   SLASDQ,
+      EXTERNAL           SCOPY, SLARTG, SLASCL, SLASD0, SLASDA, SLASDQ,
      $                   SLASET, SLASR, SSWAP, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
@@ -341,17 +340,14 @@
          IF( ICOMPQ.EQ.2 ) THEN
             CALL SLASET( 'A', N, N, ZERO, ONE, U, LDU )
             CALL SLASET( 'A', N, N, ZERO, ONE, VT, LDVT )
-            CALL SLASDQ( 'U', 0, N, N, N, 0, D, E, VT, LDVT, U, LDU,
-     $                   U,
+            CALL SLASDQ( 'U', 0, N, N, N, 0, D, E, VT, LDVT, U, LDU, U,
      $                   LDU, WORK( WSTART ), INFO )
          ELSE IF( ICOMPQ.EQ.1 ) THEN
             IU = 1
             IVT = IU + N
-            CALL SLASET( 'A', N, N, ZERO, ONE,
-     $                   Q( IU+( QSTART-1 )*N ),
+            CALL SLASET( 'A', N, N, ZERO, ONE, Q( IU+( QSTART-1 )*N ),
      $                   N )
-            CALL SLASET( 'A', N, N, ZERO, ONE,
-     $                   Q( IVT+( QSTART-1 )*N ),
+            CALL SLASET( 'A', N, N, ZERO, ONE, Q( IVT+( QSTART-1 )*N ),
      $                   N )
             CALL SLASDQ( 'U', 0, N, N, N, 0, D, E,
      $                   Q( IVT+( QSTART-1 )*N ), N,
@@ -509,8 +505,7 @@
 *     which rotated B to be upper bidiagonal
 *
       IF( ( IUPLO.EQ.2 ) .AND. ( ICOMPQ.EQ.2 ) )
-     $   CALL SLASR( 'L', 'V', 'B', N, N, WORK( 1 ), WORK( N ), U,
-     $               LDU )
+     $   CALL SLASR( 'L', 'V', 'B', N, N, WORK( 1 ), WORK( N ), U, LDU )
 *
       RETURN
 *


### PR DESCRIPTION
Reverts OpenMathLib/OpenBLAS#5936 as Reference-LAPACK ultimately rejected the PR this is based on