### PR TITLE
wasm: guard remaining KERNEL assignments so KERNEL.$(TARGET_CORE) overrides survive

### DIFF
--- a/kernel/wasm/KERNEL
+++ b/kernel/wasm/KERNEL
@@ -1,44 +1,108 @@
+ifndef SAMAXKERNEL
 SAMAXKERNEL  = ../riscv64/amax.c
+endif
+ifndef DAMAXKERNEL
 DAMAXKERNEL  = ../riscv64/amax.c
+endif
+ifndef CAMAXKERNEL
 CAMAXKERNEL  = ../riscv64/zamax.c
+endif
+ifndef ZAMAXKERNEL
 ZAMAXKERNEL  = ../riscv64/zamax.c
+endif
 
+ifndef SAMINKERNEL
 SAMINKERNEL  = ../riscv64/amin.c
+endif
+ifndef DAMINKERNEL
 DAMINKERNEL  = ../riscv64/amin.c
+endif
+ifndef CAMINKERNEL
 CAMINKERNEL  = ../riscv64/zamin.c
+endif
+ifndef ZAMINKERNEL
 ZAMINKERNEL  = ../riscv64/zamin.c
+endif
 
+ifndef SMAXKERNEL
 SMAXKERNEL   = ../riscv64/max.c
+endif
+ifndef DMAXKERNEL
 DMAXKERNEL   = ../riscv64/max.c
+endif
 
+ifndef SMINKERNEL
 SMINKERNEL   = ../riscv64/min.c
+endif
+ifndef DMINKERNEL
 DMINKERNEL   = ../riscv64/min.c
+endif
 
+ifndef ISAMAXKERNEL
 ISAMAXKERNEL = ../riscv64/iamax.c
+endif
+ifndef IDAMAXKERNEL
 IDAMAXKERNEL = ../riscv64/iamax.c
+endif
+ifndef ICAMAXKERNEL
 ICAMAXKERNEL = ../riscv64/izamax.c
+endif
+ifndef IZAMAXKERNEL
 IZAMAXKERNEL = ../riscv64/izamax.c
+endif
 
+ifndef ISAMINKERNEL
 ISAMINKERNEL = ../riscv64/iamin.c
+endif
+ifndef IDAMINKERNEL
 IDAMINKERNEL = ../riscv64/iamin.c
+endif
+ifndef ICAMINKERNEL
 ICAMINKERNEL = ../riscv64/izamin.c
+endif
+ifndef IZAMINKERNEL
 IZAMINKERNEL = ../riscv64/izamin.c
+endif
 
+ifndef ISMAXKERNEL
 ISMAXKERNEL  = ../riscv64/imax.c
+endif
+ifndef IDMAXKERNEL
 IDMAXKERNEL  = ../riscv64/imax.c
+endif
 
+ifndef ISMINKERNEL
 ISMINKERNEL  = ../riscv64/imin.c
+endif
+ifndef IDMINKERNEL
 IDMINKERNEL  = ../riscv64/imin.c
+endif
 
+ifndef SASUMKERNEL
 SASUMKERNEL  = ../riscv64/asum.c
+endif
+ifndef DASUMKERNEL
 DASUMKERNEL  = ../riscv64/asum.c
+endif
+ifndef CASUMKERNEL
 CASUMKERNEL  = ../riscv64/zasum.c
+endif
+ifndef ZASUMKERNEL
 ZASUMKERNEL  = ../riscv64/zasum.c
+endif
 
+ifndef SSUMKERNEL
 SSUMKERNEL  = ../arm/sum.c
+endif
+ifndef DSUMKERNEL
 DSUMKERNEL  = ../arm/sum.c
+endif
+ifndef CSUMKERNEL
 CSUMKERNEL  = ../arm/zsum.c
+endif
+ifndef ZSUMKERNEL
 ZSUMKERNEL  = ../arm/zsum.c
+endif
 
 ifndef SAXPYKERNEL
 SAXPYKERNEL  = ../riscv64/axpy.c
@@ -46,48 +110,116 @@ endif
 ifndef DAXPYKERNEL
 DAXPYKERNEL  = ../riscv64/axpy.c
 endif
+ifndef CAXPYKERNEL
 CAXPYKERNEL  = ../riscv64/zaxpy.c
+endif
+ifndef ZAXPYKERNEL
 ZAXPYKERNEL  = ../riscv64/zaxpy.c
+endif
 
+ifndef SAXPBYKERNEL
 SAXPBYKERNEL  = ../riscv64/axpby.c
+endif
+ifndef DAXPBYKERNEL
 DAXPBYKERNEL  = ../riscv64/axpby.c
+endif
+ifndef CAXPBYKERNEL
 CAXPBYKERNEL  = ../riscv64/zaxpby.c
+endif
+ifndef ZAXPBYKERNEL
 ZAXPBYKERNEL  = ../riscv64/zaxpby.c
+endif
 
+ifndef SCOPYKERNEL
 SCOPYKERNEL  = ../riscv64/copy.c
+endif
+ifndef DCOPYKERNEL
 DCOPYKERNEL  = ../riscv64/copy.c
+endif
+ifndef CCOPYKERNEL
 CCOPYKERNEL  = ../riscv64/zcopy.c
+endif
+ifndef ZCOPYKERNEL
 ZCOPYKERNEL  = ../riscv64/zcopy.c
+endif
 
+ifndef SDOTKERNEL
 SDOTKERNEL   = ../riscv64/dot.c
+endif
+ifndef DDOTKERNEL
 DDOTKERNEL   = ../riscv64/dot.c
+endif
+ifndef CDOTKERNEL
 CDOTKERNEL   = ../riscv64/zdot.c
+endif
+ifndef ZDOTKERNEL
 ZDOTKERNEL   = ../riscv64/zdot.c
+endif
+ifndef DSDOTKERNEL
 DSDOTKERNEL  = ../generic/dot.c
+endif
 
+ifndef SNRM2KERNEL
 SNRM2KERNEL  = ../riscv64/nrm2.c
+endif
+ifndef DNRM2KERNEL
 DNRM2KERNEL  = ../riscv64/nrm2.c
+endif
+ifndef CNRM2KERNEL
 CNRM2KERNEL  = ../riscv64/znrm2.c
+endif
+ifndef ZNRM2KERNEL
 ZNRM2KERNEL  = ../riscv64/znrm2.c
+endif
 
+ifndef SROTKERNEL
 SROTKERNEL   = ../riscv64/rot.c
+endif
+ifndef DROTKERNEL
 DROTKERNEL   = ../riscv64/rot.c
+endif
+ifndef CROTKERNEL
 CROTKERNEL   = ../riscv64/zrot.c
+endif
+ifndef ZROTKERNEL
 ZROTKERNEL   = ../riscv64/zrot.c
+endif
 
+ifndef SROTMKERNEL
 SROTMKERNEL  = ../generic/rotm.c
+endif
+ifndef DROTMKERNEL
 DROTMKERNEL  = ../generic/rotm.c
+endif
+ifndef QROTMKERNEL
 QROTMKERNEL = ../generic/rotm.c
+endif
 
+ifndef SSCALKERNEL
 SSCALKERNEL  = ../riscv64/scal.c
+endif
+ifndef DSCALKERNEL
 DSCALKERNEL  = ../riscv64/scal.c
+endif
+ifndef CSCALKERNEL
 CSCALKERNEL  = ../riscv64/zscal.c
+endif
+ifndef ZSCALKERNEL
 ZSCALKERNEL  = ../riscv64/zscal.c
+endif
 
+ifndef SSWAPKERNEL
 SSWAPKERNEL  = ../riscv64/swap.c
+endif
+ifndef DSWAPKERNEL
 DSWAPKERNEL  = ../riscv64/swap.c
+endif
+ifndef CSWAPKERNEL
 CSWAPKERNEL  = ../riscv64/zswap.c
+endif
+ifndef ZSWAPKERNEL
 ZSWAPKERNEL  = ../riscv64/zswap.c
+endif
 
 ifndef SGEMVNKERNEL
 SGEMVNKERNEL = ../riscv64/gemv_n.c
@@ -95,8 +227,12 @@ endif
 ifndef DGEMVNKERNEL
 DGEMVNKERNEL = ../riscv64/gemv_n.c
 endif
+ifndef CGEMVNKERNEL
 CGEMVNKERNEL = ../riscv64/zgemv_n.c
+endif
+ifndef ZGEMVNKERNEL
 ZGEMVNKERNEL = ../riscv64/zgemv_n.c
+endif
 
 ifndef SGEMVTKERNEL
 SGEMVTKERNEL = ../riscv64/gemv_t.c
@@ -104,8 +240,12 @@ endif
 ifndef DGEMVTKERNEL
 DGEMVTKERNEL = ../riscv64/gemv_t.c
 endif
+ifndef CGEMVTKERNEL
 CGEMVTKERNEL = ../riscv64/zgemv_t.c
+endif
+ifndef ZGEMVTKERNEL
 ZGEMVTKERNEL = ../riscv64/zgemv_t.c
+endif
 
 # KERNEL.$(TARGET_CORE) is included first; keep its TRMM width if set.
 # Unroll-4 GEMM packing uses trmm_*copy_4, which is wrong with a 2x2 kernel.
@@ -212,31 +352,71 @@ ifndef DTRSMKERNEL_RT
 DTRSMKERNEL_RT	= ../generic/trsm_kernel_RT.c
 endif
 
+ifndef CTRSMKERNEL_LN
 CTRSMKERNEL_LN	= ../generic/trsm_kernel_LN.c
+endif
+ifndef CTRSMKERNEL_LT
 CTRSMKERNEL_LT	= ../generic/trsm_kernel_LT.c
+endif
+ifndef CTRSMKERNEL_RN
 CTRSMKERNEL_RN	= ../generic/trsm_kernel_RN.c
+endif
+ifndef CTRSMKERNEL_RT
 CTRSMKERNEL_RT	= ../generic/trsm_kernel_RT.c
+endif
 
+ifndef ZTRSMKERNEL_LN
 ZTRSMKERNEL_LN	= ../generic/trsm_kernel_LN.c
+endif
+ifndef ZTRSMKERNEL_LT
 ZTRSMKERNEL_LT	= ../generic/trsm_kernel_LT.c
+endif
+ifndef ZTRSMKERNEL_RN
 ZTRSMKERNEL_RN	= ../generic/trsm_kernel_RN.c
+endif
+ifndef ZTRSMKERNEL_RT
 ZTRSMKERNEL_RT	= ../generic/trsm_kernel_RT.c
+endif
 
+ifndef SSYMV_U_KERNEL
 SSYMV_U_KERNEL =  ../generic/symv_k.c
+endif
+ifndef SSYMV_L_KERNEL
 SSYMV_L_KERNEL =  ../generic/symv_k.c
+endif
+ifndef DSYMV_U_KERNEL
 DSYMV_U_KERNEL =  ../generic/symv_k.c
+endif
+ifndef DSYMV_L_KERNEL
 DSYMV_L_KERNEL =  ../generic/symv_k.c
+endif
+ifndef CSYMV_U_KERNEL
 CSYMV_U_KERNEL =  ../generic/zsymv_k.c
+endif
+ifndef CSYMV_L_KERNEL
 CSYMV_L_KERNEL =  ../generic/zsymv_k.c
+endif
+ifndef ZSYMV_U_KERNEL
 ZSYMV_U_KERNEL =  ../generic/zsymv_k.c
+endif
+ifndef ZSYMV_L_KERNEL
 ZSYMV_L_KERNEL =  ../generic/zsymv_k.c
+endif
 
 
+ifndef LSAME_KERNEL
 LSAME_KERNEL = ../generic/lsame.c
+endif
 
+ifndef SCABS_KERNEL
 SCABS_KERNEL	= ../generic/cabs.c
+endif
+ifndef DCABS_KERNEL
 DCABS_KERNEL	= ../generic/cabs.c
+endif
+ifndef QCABS_KERNEL
 QCABS_KERNEL	= ../generic/cabs.c
+endif
 
 ifndef SGEMM_BETA
 SGEMM_BETA = ../generic/gemm_beta.c


### PR DESCRIPTION
Fixes #5993. Base `kernel/wasm/KERNEL` is included after `KERNEL.$(TARGET_CORE)` (`kernel/Makefile:119-121`), so unguarded `=` assignments in the base file clobber per-target overrides. #5984 (AXPY), #5983 (GEMM/TRMM), and #5990 (GEMV) fixed this family-by-family; this PR wraps every remaining assignment in `ifndef` so future WASM sub-targets can override any kernel without a matching guard edit here.

On `develop`, the still-unguarded families this PR moves are SDOT / DDOT / SROT / DROT. SIMD-opcode counts in `libopenblas.so` for these kernels (measured against the `v0.3.34` tag, since that predates the prior guard PRs):

| kernel  | simd_before | simd_after |
|---------|------------:|-----------:|
| sdot_k  |           0 |         27 |
| ddot_k  |           0 |         25 |
| srot_k  |          12 |         74 |
| drot_k  |          12 |         66 |

Downstream (emscripten-forge/recipes#6343): 1.5-2x speedup on `numpy.correlate` under Node/Emscripten (`TARGET=WASM128_GENERIC`, `USE_THREAD=0`).

Tested with `utest` and CBLAS `ctest` L1/L2/L3 under Node.