### PR TITLE
wasm: use relaxed-simd madd for v_muladd when available

### DIFF
--- a/kernel/simd/intrin_wasm.h
+++ b/kernel/simd/intrin_wasm.h
@@ -21,11 +21,19 @@ typedef v128_t v_f64;
 #define v_mul_f32 wasm_f32x4_mul
 #define v_mul_f64 wasm_f64x2_mul
 
+#ifdef __wasm_relaxed_simd__
+BLAS_FINLINE v_f32 v_muladd_f32(v_f32 a, v_f32 b, v_f32 c)
+{ return wasm_f32x4_relaxed_madd(a, b, c); }
+
+BLAS_FINLINE v_f64 v_muladd_f64(v_f64 a, v_f64 b, v_f64 c)
+{ return wasm_f64x2_relaxed_madd(a, b, c); }
+#else
 BLAS_FINLINE v_f32 v_muladd_f32(v_f32 a, v_f32 b, v_f32 c)
 { return v_add_f32(v_mul_f32(a, b), c); }
 
 BLAS_FINLINE v_f64 v_muladd_f64(v_f64 a, v_f64 b, v_f64 c)
 { return v_add_f64(v_mul_f64(a, b), c); }
+#endif
 
 BLAS_FINLINE v_f32 v_mulsub_f32(v_f32 a, v_f32 b, v_f32 c)
 { return v_sub_f32(v_mul_f32(a, b), c); }


### PR DESCRIPTION
## Summary

When emcc is invoked with `-mrelaxed-simd`, `__wasm_relaxed_simd__` is defined and the `wasm_f{32x4,64x2}_relaxed_madd` intrinsics become available. These lower to hardware FMA on engines that support wasm relaxed-simd (Chrome >=114, Firefox >=120, Safari >=16.4, Node >=22) and to a separate mul+add otherwise, so callers get FMA where possible with no ABI change.

Off by default: builds that do not pass `-mrelaxed-simd` fall through to the existing separate mul+add definitions of `v_muladd_f32` / `v_muladd_f64`, so no behavior change for the default wasm build.

## Notes

- Change is scoped to `kernel/simd/intrin_wasm.h` (+8 lines).
- Level-3 wasm128 kernels (`gemmkernel_4x4_wasm128.c`, `trmmkernel_4x4_wasm128.c`, `zgemmkernel_2x2_wasm128.c`) already call `wasm_f{32x4,64x2}_relaxed_madd` directly under `__wasm_relaxed_simd__`. This patch extends the same behavior to everything that goes through `v_muladd`, so Level-1 kernels benefit too.
- Downstream verification (built with `-msimd128 -mrelaxed-simd`, disassembled with `wasm2wat`): 25 additional `relaxed_madd` emissions attributable to this patch, in `sdsdot_k` (10) and `sdot_k` / `ddot_k` / `srot_k` (5 each) via `kernel/generic/dot.c`.
- Preliminary benchmark: on a large-n `numpy.correlate` workload, wasm overhead vs. native drops from ~7x to ~3.5x on relaxed-simd-capable engines (roughly 2x speedup of the wasm build itself). More rigorous benchmarks needed to confirm.