### PR TITLE
Improve f_check when assembly has no vendor identity

### DIFF
--- a/f_check
+++ b/f_check
@@ -76,6 +76,9 @@ else
     	if [ -z "$data" ]; then
     		data=`$compiler -O2 -S ftest.f > /dev/null 2>&1 && cat ftest.c && rm -f ftest.c`
     	fi
+    	# Some compilers (e.g. Intel ifx) embed no vendor identity in the assembly;
+    	# append the --version banner so the vendor detection below can match them.
+    	ver=`$compiler --version 2>&1` && data=`printf '%s\n%s' "$data" "$ver"`
 
         case "$data" in *zhoge_*) bu=_ ;; esac
 

--- a/f_check.pl
+++ b/f_check.pl
@@ -19,7 +19,7 @@ $nofortran = 0;
 
 $compiler = join(" ", @ARGV);
 $compiler_bin = shift(@ARGV);
- 
+
 # f77 is too ambiguous
 $compiler = "" if $compiler eq "f77";
 
@@ -66,6 +66,10 @@ if ($compiler eq "") {
 	$data = `$compiler -O2 -S ftest.f > /dev/null 2>&1 && cat ftest.s && rm -f ftest.s`;
 	if ($data eq "") {
 		$data = `$compiler -O2 -S ftest.f > /dev/null 2>&1 && cat ftest.c && rm -f ftest.c`;
+	}
+	my $ver = `$compiler --version 2>&1`;
+	if (!$?) {
+		$data = "$data\n$ver";
 	}
 	if ($data =~ /zhoge_/) {
 	    $bu       = "_";
@@ -323,7 +327,7 @@ $linker_a = "";
 if ($link ne "") {
 
     $link =~ s/\-Y\sP\,/\-Y/g;
-    
+
     $link =~ s/\-R\s*/\-rpath\%/g;
 
     $link =~ s/\-rpath\s+/\-rpath\%/g;


### PR DESCRIPTION
Vendor detection in f_check greps the probe assembly (ftest.s) for a compiler identity string. Some compilers, notably Intel ifx, emit no such string, so the primary `case "$data"` scan fails to set a vendor.

The name-based fallback only recognizes bare compiler names, so an ifx-backed wrapper (e.g. mpif90, mpifort or the Cray ftn wrapper) is not matched either, leaving the vendor empty and resulting in a false conclusion that no Fortran compilers are available.

Append the output of `$compiler --version` to $data so such compilers are identified by their version banner (ifx's contains "ifx", "Intel").