### PR TITLE
Fix ARM64 ASIMD dot kernel operand constraints under LTO

### DIFF
--- a/kernel/arm64/dot_kernel_asimd.c
+++ b/kernel/arm64/dot_kernel_asimd.c
@@ -332,13 +332,13 @@ static RETURN_TYPE dot_kernel_asimd(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT 
 
 	"9: //dot_kernel_L999:				\n"
 
-	: [DOT_]  "=&w" (dot)
-	: [N_]    "r"   (n),
-	  [X_]    "r"   (x),
-	  [INCX_] "r"   (inc_x),
-	  [Y_]    "r"   (y),
-	  [INCY_] "r"   (inc_y),
-          [J_]    "r"   (j)
+	: [DOT_]  "=&w" (dot),
+	  [X_]    "+&r" (x),
+	  [INCX_] "+&r" (inc_x),
+	  [Y_]    "+&r" (y),
+	  [INCY_] "+&r" (inc_y),
+	  [J_]    "+&r" (j)
+	: [N_]    "r"   (n)
 	: "cc",
 	  "memory",
 	  "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",

--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -19,6 +19,7 @@ else ()
     test_amin.c
     test_axpby.c
     test_gemv.c
+    test_trmv.c
   )
 endif ()
 

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -14,7 +14,7 @@ UTESTEXTBIN=openblas_utest_ext$(EXE)
 include $(TOPDIR)/Makefile.system
 
 OBJS=utest_main.o test_min.o test_amax.o test_ismin.o test_rotmg.o test_axpy.o test_dotu.o test_dsdot.o test_swap.o test_rot.o test_dnrm2.o test_zscal.o \
-     test_amin.o test_axpby.o test_gemv.o
+     test_amin.o test_axpby.o test_gemv.o test_trmv.o
 #test_rot.o test_swap.o test_axpy.o test_dotu.o test_dsdot.o test_fork.o
 OBJS_EXT=utest_main.o $(DIR_EXT)/xerbla.o $(DIR_EXT)/common.o 
 OBJS_EXT+=$(DIR_EXT)/test_isamin.o $(DIR_EXT)/test_idamin.o $(DIR_EXT)/test_icamin.o $(DIR_EXT)/test_izamin.o 

--- a/utest/test_trmv.c
+++ b/utest/test_trmv.c
@@ -1,0 +1,61 @@
+/*****************************************************************************
+Copyright (c) 2026, The OpenBLAS Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+   3. Neither the name of OpenBLAS nor the names of its contributors may
+      be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+**********************************************************************************/
+
+#include "openblas_utest.h"
+#include <cblas.h>
+
+#if defined(BUILD_SINGLE) && !defined(NO_CBLAS)
+
+/*
+ * Regression test for equal unit strides in the ARM64 ASIMD dot kernel
+ * under LTO.
+ */
+CTEST(strmv, small_rowmajor_lower_notrans_unit_stride)
+{
+    const float lower[9] = {
+        2.0f, 0.0f, 0.0f,
+        3.0f, 4.0f, 0.0f,
+        5.0f, 6.0f, 7.0f
+    };
+    const float expected[3] = {22.0f, 85.0f, 252.0f};
+    float vector[3] = {11.0f, 13.0f, 17.0f};
+    int i;
+
+    cblas_strmv(CblasRowMajor, CblasLower, CblasNoTrans,
+                CblasNonUnit, 3, lower, 3, vector, 1);
+
+    for (i = 0; i < 3; i++)
+        ASSERT_DBL_NEAR_TOL(expected[i], vector[i], SINGLE_EPS);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Fix incorrect operand constraints in the ARM64 ASIMD dot kernel that can produce wrong results with GCC full LTO. A small `cblas_strmv` regression test is included.

## Cause and fix

An inline-assembly block has the instructions themselves and an operand list describing their effects to the compiler. GCC does not derive those effects from the instructions. Here the operand list says that the array pointers (`x`, `y`), their strides (`inc_x`, `inc_y`), and the loop counter (`j`) are only read, although the instructions overwrite all five.

This becomes a real failure under full LTO. GCC sees that both strides are `1` and, based on the incorrect operand list, may keep them in the same register. The kernel converts each stride from elements to bytes by multiplying it by four because one `float` occupies four bytes:

```text
expected: inc_x 1 -> 4, inc_y 1 -> 4
actual:   shared register 1 -> 4 -> 16
```

The shared register is therefore multiplied twice and becomes `16`. The pointers advance 16 bytes (four floats) instead of 4 bytes (one float), so the dot product reads the wrong elements.

Declaring the five values as `+&r` fixes the contract: `+` tells GCC that the value is both read and overwritten, while `&` prevents its register from being reused for another still-live input (`r` selects a general-purpose register). This keeps the two strides separate. `n`, which is not modified, remains input-only. The assembly instructions and numerical operations are unchanged.

This is separate from OpenMathLib/OpenBLAS#5917 and OpenMathLib/OpenBLAS#5918, which fixed accumulator initialization and vector-register clobbers in the same kernel.

## Validation

Tested on Linux AArch64 with static, single-threaded VORTEX builds and full LTO:

- Unmodified `develop` with the new test: fails with `expected 85, got 52`.
- This branch with GCC 15.2.0: all 125 unit tests pass.
- This branch with Clang 22.1.3: all 125 unit tests pass.
- GNU Make and CMake test builds pass.

The reproducer multiplies a 3x3 lower-triangular matrix by `[11, 13, 17]`; the correct result is `[22, 85, 252]`.

## CI coverage

Permanently covering the original failure would require an additional static VORTEX full-LTO ARM64 job. That is possible, but the ongoing runner cost and maintenance seem disproportionate for this narrow case, so this PR only adds the regression test. I can add targeted CI coverage if maintainers prefer.
