### PR TITLE
Confirm SVE capability before assigning ARMV9SME in DYNAMIC_ARCH

### DIFF
--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -541,7 +541,10 @@ static gotoblas_t *get_coretype(void) {
 
 #if !defined(NO_SME)
   if (support_sme1()) {
-    return &gotoblas_ARMV9SME;
+	if ((getauxval(AT_HWCAP) & HWCAP_SVE))
+      return &gotoblas_ARMV9SME;
+	else
+	  return &gotoblas_VORTEXM4;
   }
 #endif
 


### PR DESCRIPTION
The Parallels hypervisor seems to use the generic ARM Ltd implementer_id, avoiding our Mac-specific logic.
Most likely fixes #6011