### PR TITLE
Correct signatures of the reimplemented LAPACK functions to void

### DIFF
--- a/common_interface.h
+++ b/common_interface.h
@@ -684,96 +684,96 @@ int OPENBLAS_API(xgemc)(char *, char *, blasint *, blasint *, blasint *, xdouble
 
 /* Lapack routines */
 
-int OPENBLAS_API(sgetf2)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(dgetf2)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(qgetf2)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(cgetf2)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(zgetf2)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(xgetf2)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(sgetf2)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(dgetf2)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(qgetf2)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(cgetf2)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(zgetf2)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(xgetf2)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
 
-int OPENBLAS_API(sgetrf)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(dgetrf)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(qgetrf)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(cgetrf)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(zgetrf)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(xgetrf)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(sgetrf)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(dgetrf)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(qgetrf)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(cgetrf)(blasint *, blasint *, float  *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(zgetrf)(blasint *, blasint *, double *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(xgetrf)(blasint *, blasint *, xdouble *, blasint *, blasint *, blasint *);
 
-int OPENBLAS_API(slaswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(dlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(qlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(claswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(zlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
-int OPENBLAS_API(xlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(slaswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(dlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(qlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(claswp)(blasint *, float  *, blasint *, blasint *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(zlaswp)(blasint *, double *, blasint *, blasint *, blasint *, blasint *, blasint *);
+void OPENBLAS_API(xlaswp)(blasint *, xdouble *, blasint *, blasint *, blasint *, blasint *, blasint *);
 
-int OPENBLAS_API(sgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(dgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(qgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(cgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(zgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(xgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(sgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(dgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(qgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(cgetrs)(char *, blasint *, blasint *, float  *, blasint *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(zgetrs)(char *, blasint *, blasint *, double *, blasint *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(xgetrs)(char *, blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble *, blasint *, blasint *);
 
-int OPENBLAS_API(sgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
-int OPENBLAS_API(dgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
-int OPENBLAS_API(qgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
-int OPENBLAS_API(cgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
-int OPENBLAS_API(zgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
-int OPENBLAS_API(xgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
+void OPENBLAS_API(sgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
+void OPENBLAS_API(dgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
+void OPENBLAS_API(qgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
+void OPENBLAS_API(cgesv)(blasint *, blasint *, float  *, blasint *, blasint *, float *, blasint *, blasint *);
+void OPENBLAS_API(zgesv)(blasint *, blasint *, double *, blasint *, blasint *, double*, blasint *, blasint *);
+void OPENBLAS_API(xgesv)(blasint *, blasint *, xdouble *, blasint *, blasint *, xdouble*, blasint *, blasint *);
 
-int OPENBLAS_API(spotf2)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(dpotf2)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(qpotf2)(char *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(cpotf2)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(zpotf2)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(xpotf2)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(spotf2)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(dpotf2)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(qpotf2)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(cpotf2)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(zpotf2)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(xpotf2)(char *, blasint *, xdouble *, blasint *, blasint *);
 
-int OPENBLAS_API(spotrf)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(dpotrf)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(qpotrf)(char *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(cpotrf)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(zpotrf)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(xpotrf)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(spotrf)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(dpotrf)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(qpotrf)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(cpotrf)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(zpotrf)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(xpotrf)(char *, blasint *, xdouble *, blasint *, blasint *);
 
-int OPENBLAS_API(spotri)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(dpotri)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(qpotri)(char *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(cpotri)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(zpotri)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(xpotri)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(spotri)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(dpotri)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(qpotri)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(cpotri)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(zpotri)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(xpotri)(char *, blasint *, xdouble *, blasint *, blasint *);
 
-int OPENBLAS_API(spotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *);
-int OPENBLAS_API(dpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *);
-int OPENBLAS_API(qpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(cpotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *);
-int OPENBLAS_API(zpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *);
-int OPENBLAS_API(xpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(spotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *);
+void OPENBLAS_API(dpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *);
+void OPENBLAS_API(qpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(cpotrs)(char *, blasint *, blasint *, float   *, blasint *, float   *, blasint *, blasint *);
+void OPENBLAS_API(zpotrs)(char *, blasint *, blasint *, double  *, blasint *, double  *, blasint *, blasint *);
+void OPENBLAS_API(xpotrs)(char *, blasint *, blasint *, xdouble *, blasint *, xdouble *, blasint *, blasint *);
 
-int OPENBLAS_API(slauu2)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(dlauu2)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(qlauu2)(char *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(clauu2)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(zlauu2)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(xlauu2)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(slauu2)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(dlauu2)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(qlauu2)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(clauu2)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(zlauu2)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(xlauu2)(char *, blasint *, xdouble *, blasint *, blasint *);
 
-int OPENBLAS_API(slauum)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(dlauum)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(qlauum)(char *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(clauum)(char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(zlauum)(char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(xlauum)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(slauum)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(dlauum)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(qlauum)(char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(clauum)(char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(zlauum)(char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(xlauum)(char *, blasint *, xdouble *, blasint *, blasint *);
 
-int OPENBLAS_API(strti2)(char *, char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(dtrti2)(char *, char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(qtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(ctrti2)(char *, char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(ztrti2)(char *, char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(xtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(strti2)(char *, char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(dtrti2)(char *, char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(qtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(ctrti2)(char *, char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(ztrti2)(char *, char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(xtrti2)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
 
-int OPENBLAS_API(strtri)(char *, char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(dtrtri)(char *, char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(qtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
-int OPENBLAS_API(ctrtri)(char *, char *, blasint *, float  *, blasint *, blasint *);
-int OPENBLAS_API(ztrtri)(char *, char *, blasint *, double *, blasint *, blasint *);
-int OPENBLAS_API(xtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(strtri)(char *, char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(dtrtri)(char *, char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(qtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
+void OPENBLAS_API(ctrtri)(char *, char *, blasint *, float  *, blasint *, blasint *);
+void OPENBLAS_API(ztrtri)(char *, char *, blasint *, double *, blasint *, blasint *);
+void OPENBLAS_API(xtrtri)(char *, char *, blasint *, xdouble *, blasint *, blasint *);
 
 
 FLOATRET  OPENBLAS_API(slamch)(char *);

--- a/interface/lapack/gesv.c
+++ b/interface/lapack/gesv.c
@@ -61,7 +61,7 @@
 #endif
 
 OPENBLAS_EXPORT
-int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
+void NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
          FLOAT *b, blasint *ldB, blasint *Info){
 
   blas_arg_t args;
@@ -92,7 +92,7 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   args.alpha = NULL;
@@ -100,7 +100,7 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
 
   *Info = 0;
 
-  if (args.m == 0) return 0;
+  if (args.m == 0) return;
 
   IDEBUG_START;
 
@@ -172,5 +172,5 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/getf2.c
+++ b/interface/lapack/getf2.c
@@ -51,7 +51,7 @@
 #endif
 
 OPENBLAS_EXPORT
-int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
+void NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
 
   blas_arg_t args;
 
@@ -77,11 +77,11 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
-  if (args.m == 0 || args.n == 0) return 0;
+  if (args.m == 0 || args.n == 0) return;
 
   IDEBUG_START;
 
@@ -106,5 +106,5 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/getrf.c
+++ b/interface/lapack/getrf.c
@@ -51,7 +51,7 @@
 #endif
 
 OPENBLAS_EXPORT
-int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
+void NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
 
   blas_arg_t args;
 
@@ -77,11 +77,11 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
-  if (args.m == 0 || args.n == 0) return 0;
+  if (args.m == 0 || args.n == 0) return;
 
   IDEBUG_START;
 
@@ -130,5 +130,5 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/getrs.c
+++ b/interface/lapack/getrs.c
@@ -61,7 +61,7 @@ static blasint (*getrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+void NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
   blasint *ipiv, FLOAT *b, blasint *ldB, blasint *Info){
 
   char trans_arg = *TRANS;
@@ -104,7 +104,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 
   if (info != 0) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
-    return 0;
+    return;
   }
 
   args.alpha = NULL;
@@ -112,7 +112,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 
   *Info = info;
 
-  if (args.m == 0 || args.n == 0) return 0;
+  if (args.m == 0 || args.n == 0) return;
 
   IDEBUG_START;
 
@@ -152,6 +152,6 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 
   IDEBUG_END;
 
-  return 0;
+  return;
 
 }

--- a/interface/lapack/laed3.c
+++ b/interface/lapack/laed3.c
@@ -41,7 +41,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* ===================================================================== */
 OPENBLAS_EXPORT
-int NAME(blasint *k, blasint *n, blasint *n1, FLOAT *d, 
+void NAME(blasint *k, blasint *n, blasint *n1, FLOAT *d, 
         FLOAT *q, blasint *ldq, FLOAT *rho, FLOAT *dlamda,
         FLOAT *q2, blasint *indx, blasint *ctot, FLOAT *w, 
         FLOAT *s, blasint *Info)
@@ -64,13 +64,13 @@ int NAME(blasint *k, blasint *n, blasint *n1, FLOAT *d,
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
 /*   Quick return if possible */
 
   *Info = 0;
-  if (kval == 0) return 0;
+  if (kval == 0) return;
 
 #ifdef SMP
   int nthreads = 1;
@@ -85,5 +85,5 @@ int NAME(blasint *k, blasint *n, blasint *n1, FLOAT *d,
   }
 #endif
 
-  return 0;
+  return;
 }

--- a/interface/lapack/laswp.c
+++ b/interface/lapack/laswp.c
@@ -53,7 +53,7 @@ static int (*laswp[])(BLASLONG, BLASLONG, BLASLONG, FLOAT, FLOAT *, BLASLONG, FL
 };
 
 OPENBLAS_EXPORT
-int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *ipiv, blasint *INCX){
+void NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *ipiv, blasint *INCX){
 
   blasint n    = *N;
   blasint lda  = *LDA;
@@ -69,7 +69,7 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
 
   PRINT_DEBUG_NAME;
 
-  if (incx == 0 || n <= 0) return 0;
+  if (incx == 0 || n <= 0) return;
 
   IDEBUG_START;
 
@@ -110,6 +110,6 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
 
   IDEBUG_END;
 
-  return 0;
+  return;
 
 }

--- a/interface/lapack/lauu2.c
+++ b/interface/lapack/lauu2.c
@@ -61,7 +61,7 @@ static blasint (*lauu2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
   };
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -93,12 +93,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n <= 0) return 0;
+  if (args.n <= 0) return;
 
   IDEBUG_START;
 
@@ -125,5 +125,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/lauum.c
+++ b/interface/lapack/lauum.c
@@ -61,7 +61,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -93,12 +93,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n == 0) return 0;
+  if (args.n == 0) return;
 
   IDEBUG_START;
 
@@ -140,5 +140,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/potf2.c
+++ b/interface/lapack/potf2.c
@@ -61,7 +61,7 @@ static blasint (*potf2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
   };
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -93,12 +93,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n <= 0) return 0;
+  if (args.n <= 0) return;
 
   IDEBUG_START;
 
@@ -125,5 +125,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/potrf.c
+++ b/interface/lapack/potrf.c
@@ -61,7 +61,7 @@ static blasint (*potrf_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -93,12 +93,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n == 0) return 0;
+  if (args.n == 0) return;
 
   IDEBUG_START;
 
@@ -147,5 +147,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/potri.c
+++ b/interface/lapack/potri.c
@@ -69,7 +69,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -102,12 +102,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n == 0) return 0;
+  if (args.n == 0) return;
 
   IDEBUG_START;
 
@@ -160,5 +160,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/trti2.c
+++ b/interface/lapack/trti2.c
@@ -61,7 +61,7 @@ static blasint (*trti2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
   };
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -99,12 +99,12 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n <= 0) return 0;
+  if (args.n <= 0) return;
 
   IDEBUG_START;
 
@@ -131,5 +131,5 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/trtri.c
+++ b/interface/lapack/trtri.c
@@ -62,7 +62,7 @@ static blasint (*trtri_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -102,17 +102,17 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n == 0) return 0;
+  if (args.n == 0) return;
 
   if (diag) {
     if (AMIN_K(args.n, args.a, args.lda + 1) == ZERO) {
       *Info = IAMIN_K(args.n, args.a, args.lda + 1);
-      return 0;
+      return;
     }
   }
 
@@ -156,5 +156,5 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/trtrs.c
+++ b/interface/lapack/trtrs.c
@@ -61,7 +61,7 @@ static blasint (*trtrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+void NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
   FLOAT *b, blasint *ldB, blasint *Info){
 
     char uplo_arg = *UPLO;
@@ -117,7 +117,7 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
   if (info != 0) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   args.alpha = NULL;
@@ -125,12 +125,12 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
 
   *Info = 0;
 
-  if (args.m == 0) return 0;
+  if (args.m == 0) return;
 
   if (diag) {
     if (AMIN_K(args.m, args.a, args.lda + 1) == ZERO) {
       *Info = IAMIN_K(args.m, args.a, args.lda + 1);
-      return 0;
+      return;
     }
   }
 
@@ -173,6 +173,6 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
 
   IDEBUG_END;
 
-  return 0;
+  return;
 
 }

--- a/interface/lapack/zgetf2.c
+++ b/interface/lapack/zgetf2.c
@@ -51,7 +51,7 @@
 #endif
 
 OPENBLAS_EXPORT
-int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
+void NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
 
   blas_arg_t args;
 
@@ -77,11 +77,11 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
-  if (args.m == 0 || args.n == 0) return 0;
+  if (args.m == 0 || args.n == 0) return;
 
   IDEBUG_START;
 
@@ -106,5 +106,5 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/zgetrf.c
+++ b/interface/lapack/zgetrf.c
@@ -51,7 +51,7 @@
 #endif
 
 OPENBLAS_EXPORT
-int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
+void NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint *Info){
 
   blas_arg_t args;
 
@@ -77,11 +77,11 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
-  if (args.m == 0 || args.n == 0) return 0;
+  if (args.m == 0 || args.n == 0) return;
 
   IDEBUG_START;
 
@@ -122,5 +122,5 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/zgetrs.c
+++ b/interface/lapack/zgetrs.c
@@ -61,7 +61,7 @@ static blasint (*getrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+void NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 	    blasint *ipiv, FLOAT *b, blasint *ldB, blasint *Info){
 
   char trans_arg = *TRANS;
@@ -104,7 +104,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 
   if (info != 0) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
-    return 0;
+    return;
   }
 
   args.alpha = NULL;
@@ -112,7 +112,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 
   *Info = info;
 
-  if (args.m == 0 || args.n == 0) return 0;
+  if (args.m == 0 || args.n == 0) return;
 
   IDEBUG_START;
 
@@ -153,6 +153,6 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 
   IDEBUG_END;
 
-  return 0;
+  return;
 
 }

--- a/interface/lapack/zlaswp.c
+++ b/interface/lapack/zlaswp.c
@@ -53,7 +53,7 @@ static int (*laswp[])(BLASLONG, BLASLONG, BLASLONG, FLOAT, FLOAT, FLOAT *, BLASL
 };
 
 OPENBLAS_EXPORT
-int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *ipiv, blasint *INCX){
+void NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *ipiv, blasint *INCX){
 
   blasint n    = *N;
   blasint lda  = *LDA;
@@ -70,7 +70,7 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
 
   PRINT_DEBUG_NAME;
 
-  if (incx == 0 || n <= 0) return 0;
+  if (incx == 0 || n <= 0) return;
 
   IDEBUG_START;
 
@@ -109,5 +109,5 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/zlauu2.c
+++ b/interface/lapack/zlauu2.c
@@ -62,7 +62,7 @@ static blasint (*lauu2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
   };
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -94,12 +94,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n <= 0) return 0;
+  if (args.n <= 0) return;
 
   IDEBUG_START;
 
@@ -126,5 +126,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/zlauum.c
+++ b/interface/lapack/zlauum.c
@@ -61,7 +61,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -93,12 +93,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n == 0) return 0;
+  if (args.n == 0) return;
 
   IDEBUG_START;
 
@@ -142,5 +142,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/zpotf2.c
+++ b/interface/lapack/zpotf2.c
@@ -62,7 +62,7 @@ static blasint (*potf2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
   };
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -94,12 +94,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n <= 0) return 0;
+  if (args.n <= 0) return;
 
   IDEBUG_START;
 
@@ -126,5 +126,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/zpotrf.c
+++ b/interface/lapack/zpotrf.c
@@ -61,7 +61,7 @@ static blasint (*potrf_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -93,12 +93,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n == 0) return 0;
+  if (args.n == 0) return;
 
   IDEBUG_START;
 
@@ -145,5 +145,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/zpotri.c
+++ b/interface/lapack/zpotri.c
@@ -69,7 +69,7 @@ static blasint (*lauum_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -102,12 +102,12 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n == 0) return 0;
+  if (args.n == 0) return;
 
   IDEBUG_START;
 
@@ -166,5 +166,5 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/ztrti2.c
+++ b/interface/lapack/ztrti2.c
@@ -61,7 +61,7 @@ static blasint (*trti2[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *
   };
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -99,12 +99,12 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n <= 0) return 0;
+  if (args.n <= 0) return;
 
   IDEBUG_START;
 
@@ -131,5 +131,5 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/ztrtri.c
+++ b/interface/lapack/ztrtri.c
@@ -61,7 +61,7 @@ static blasint (*trtri_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
+void NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
   blas_arg_t args;
 
@@ -99,17 +99,17 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
   if (info) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   *Info = 0;
 
-  if (args.n == 0) return 0;
+  if (args.n == 0) return;
 
   if (diag) {
     if (AMIN_K(args.n, args.a, args.lda + 1) == ZERO) {
       *Info = IAMIN_K(args.n, args.a, args.lda + 1);
-      return 0;
+      return;
     }
   }
 
@@ -155,5 +155,5 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
 
   IDEBUG_END;
 
-  return 0;
+  return;
 }

--- a/interface/lapack/ztrtrs.c
+++ b/interface/lapack/ztrtrs.c
@@ -61,7 +61,7 @@ static blasint (*trtrs_parallel[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *
 #endif
 
 OPENBLAS_EXPORT
-int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
+void NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
   FLOAT *b, blasint *ldB, blasint *Info){
 
     char uplo_arg = *UPLO;
@@ -117,7 +117,7 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
   if (info != 0) {
     BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
-    return 0;
+    return;
   }
 
   args.alpha = NULL;
@@ -125,12 +125,12 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
 
   *Info = 0;
 
-  if (args.m == 0) return 0;
+  if (args.m == 0) return;
 
   if (diag) {
     if (AMIN_K(args.m, args.a, args.lda + 1) == ZERO) {
       *Info = IAMIN_K(args.m, args.a, args.lda + 1);
-      return 0;
+      return;
     }
   }
 
@@ -173,6 +173,6 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
 
   IDEBUG_END;
 
-  return 0;
+  return;
 
 }

--- a/lapack-netlib/LAPACKE/include/lapack.h
+++ b/lapack-netlib/LAPACKE/include/lapack.h
@@ -3680,28 +3680,28 @@ void LAPACK_zgedmdq_base(
 #endif
 
 #define LAPACK_cgesv LAPACK_GLOBAL(cgesv,CGESV)
-lapack_int LAPACK_cgesv(
+void LAPACK_cgesv(
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_float* B, lapack_int const* ldb,
     lapack_int* info );
 
 #define LAPACK_dgesv LAPACK_GLOBAL(dgesv,DGESV)
-lapack_int LAPACK_dgesv(
+void LAPACK_dgesv(
     lapack_int const* n, lapack_int const* nrhs,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     double* B, lapack_int const* ldb,
     lapack_int* info );
 
 #define LAPACK_sgesv LAPACK_GLOBAL(sgesv,SGESV)
-lapack_int LAPACK_sgesv(
+void LAPACK_sgesv(
     lapack_int const* n, lapack_int const* nrhs,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     float* B, lapack_int const* ldb,
     lapack_int* info );
 
 #define LAPACK_zgesv LAPACK_GLOBAL(zgesv,ZGESV)
-lapack_int LAPACK_zgesv(
+void LAPACK_zgesv(
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_complex_double* B, lapack_int const* ldb,
@@ -4300,49 +4300,49 @@ void LAPACK_zgesvxx_base(
 #endif
 
 #define LAPACK_cgetf2 LAPACK_GLOBAL(cgetf2,CGETF2)
-lapack_int LAPACK_cgetf2(
+void LAPACK_cgetf2(
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_int* info );
 
 #define LAPACK_dgetf2 LAPACK_GLOBAL(dgetf2,DGETF2)
-lapack_int LAPACK_dgetf2(
+void LAPACK_dgetf2(
     lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_int* info );
 
 #define LAPACK_sgetf2 LAPACK_GLOBAL(sgetf2,SGETF2)
-lapack_int LAPACK_sgetf2(
+void LAPACK_sgetf2(
     lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_int* info );
 
 #define LAPACK_zgetf2 LAPACK_GLOBAL(zgetf2,ZGETF2)
-lapack_int LAPACK_zgetf2(
+void LAPACK_zgetf2(
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_int* info );
 
 #define LAPACK_cgetrf LAPACK_GLOBAL(cgetrf,CGETRF)
-lapack_int LAPACK_cgetrf(
+void LAPACK_cgetrf(
     lapack_int const* m, lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_int* info );
 
 #define LAPACK_dgetrf LAPACK_GLOBAL(dgetrf,DGETRF)
-lapack_int LAPACK_dgetrf(
+void LAPACK_dgetrf(
     lapack_int const* m, lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_int* info );
 
 #define LAPACK_sgetrf LAPACK_GLOBAL(sgetrf,SGETRF)
-lapack_int LAPACK_sgetrf(
+void LAPACK_sgetrf(
     lapack_int const* m, lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_int* info );
 
 #define LAPACK_zgetrf LAPACK_GLOBAL(zgetrf,ZGETRF)
-lapack_int LAPACK_zgetrf(
+void LAPACK_zgetrf(
     lapack_int const* m, lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int* ipiv,
     lapack_int* info );
@@ -4400,7 +4400,7 @@ void LAPACK_zgetri(
     lapack_int* info );
 
 #define LAPACK_cgetrs_base LAPACK_GLOBAL(cgetrs,CGETRS)
-lapack_int LAPACK_cgetrs_base(
+void LAPACK_cgetrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda, lapack_int const* ipiv,
@@ -4417,7 +4417,7 @@ lapack_int LAPACK_cgetrs_base(
 #endif
 
 #define LAPACK_dgetrs_base LAPACK_GLOBAL(dgetrs,DGETRS)
-lapack_int LAPACK_dgetrs_base(
+void LAPACK_dgetrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda, lapack_int const* ipiv,
@@ -4434,7 +4434,7 @@ lapack_int LAPACK_dgetrs_base(
 #endif
 
 #define LAPACK_sgetrs_base LAPACK_GLOBAL(sgetrs,SGETRS)
-lapack_int LAPACK_sgetrs_base(
+void LAPACK_sgetrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda, lapack_int const* ipiv,
@@ -4451,7 +4451,7 @@ lapack_int LAPACK_sgetrs_base(
 #endif
 
 #define LAPACK_zgetrs_base LAPACK_GLOBAL(zgetrs,ZGETRS)
-lapack_int LAPACK_zgetrs_base(
+void LAPACK_zgetrs_base(
     char const* trans,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda, lapack_int const* ipiv,
@@ -11302,22 +11302,22 @@ void LAPACK_zlassq(
     double* sumsq );
 
 #define LAPACK_claswp LAPACK_GLOBAL(claswp,CLASWP)
-lapack_int LAPACK_claswp(
+void LAPACK_claswp(
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
 
 #define LAPACK_dlaswp LAPACK_GLOBAL(dlaswp,DLASWP)
-lapack_int LAPACK_dlaswp(
+void LAPACK_dlaswp(
     lapack_int const* n,
     double* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
 
 #define LAPACK_slaswp LAPACK_GLOBAL(slaswp,SLASWP)
-lapack_int LAPACK_slaswp(
+void LAPACK_slaswp(
     lapack_int const* n,
     float* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
 
 #define LAPACK_zlaswp LAPACK_GLOBAL(zlaswp,ZLASWP)
-lapack_int LAPACK_zlaswp(
+void LAPACK_zlaswp(
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda, lapack_int const* k1, lapack_int const* k2, lapack_int const* ipiv, lapack_int const* incx );
 
@@ -11410,7 +11410,7 @@ void LAPACK_zlatms_base(
 #endif
 
 #define LAPACK_clauum_base LAPACK_GLOBAL(clauum,CLAUUM)
-lapack_int LAPACK_clauum_base(
+void LAPACK_clauum_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -11426,7 +11426,7 @@ lapack_int LAPACK_clauum_base(
 #endif
 
 #define LAPACK_dlauum_base LAPACK_GLOBAL(dlauum,DLAUUM)
-lapack_int LAPACK_dlauum_base(
+void LAPACK_dlauum_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -11442,7 +11442,7 @@ lapack_int LAPACK_dlauum_base(
 #endif
 
 #define LAPACK_slauum_base LAPACK_GLOBAL(slauum,SLAUUM)
-lapack_int LAPACK_slauum_base(
+void LAPACK_slauum_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -11458,7 +11458,7 @@ lapack_int LAPACK_slauum_base(
 #endif
 
 #define LAPACK_zlauum_base LAPACK_GLOBAL(zlauum,ZLAUUM)
-lapack_int LAPACK_zlauum_base(
+void LAPACK_zlauum_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -11474,7 +11474,7 @@ lapack_int LAPACK_zlauum_base(
 #endif
 
 #define LAPACK_ilaver LAPACK_GLOBAL(ilaver,ILAVER)
-lapack_int LAPACK_ilaver(
+void LAPACK_ilaver(
     lapack_int* vers_major, lapack_int* vers_minor, lapack_int* vers_patch );
 
 #define LAPACK_dopgtr_base LAPACK_GLOBAL(dopgtr,DOPGTR)
@@ -13751,7 +13751,7 @@ void LAPACK_zpotf2_base(
 #endif
 
 #define LAPACK_cpotrf_base LAPACK_GLOBAL(cpotrf,CPOTRF)
-lapack_int LAPACK_cpotrf_base(
+void LAPACK_cpotrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -13767,7 +13767,7 @@ lapack_int LAPACK_cpotrf_base(
 #endif
 
 #define LAPACK_dpotrf_base LAPACK_GLOBAL(dpotrf,DPOTRF)
-lapack_int LAPACK_dpotrf_base(
+void LAPACK_dpotrf_base(
     char const* uplo,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -13783,7 +13783,7 @@ lapack_int LAPACK_dpotrf_base(
 #endif
 
 #define LAPACK_spotrf_base LAPACK_GLOBAL(spotrf,SPOTRF)
-lapack_int LAPACK_spotrf_base(
+void LAPACK_spotrf_base(
     char const* uplo,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -13799,7 +13799,7 @@ lapack_int LAPACK_spotrf_base(
 #endif
 
 #define LAPACK_zpotrf_base LAPACK_GLOBAL(zpotrf,ZPOTRF)
-lapack_int LAPACK_zpotrf_base(
+void LAPACK_zpotrf_base(
     char const* uplo,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,
@@ -22457,7 +22457,7 @@ void LAPACK_ztrsyl3_base(
 #endif
 
 #define LAPACK_ctrtri_base LAPACK_GLOBAL(ctrtri,CTRTRI)
-lapack_int LAPACK_ctrtri_base(
+void LAPACK_ctrtri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_float* A, lapack_int const* lda,
@@ -22473,7 +22473,7 @@ lapack_int LAPACK_ctrtri_base(
 #endif
 
 #define LAPACK_dtrtri_base LAPACK_GLOBAL(dtrtri,DTRTRI)
-lapack_int LAPACK_dtrtri_base(
+void LAPACK_dtrtri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     double* A, lapack_int const* lda,
@@ -22489,7 +22489,7 @@ lapack_int LAPACK_dtrtri_base(
 #endif
 
 #define LAPACK_strtri_base LAPACK_GLOBAL(strtri,STRTRI)
-lapack_int LAPACK_strtri_base(
+void LAPACK_strtri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     float* A, lapack_int const* lda,
@@ -22505,7 +22505,7 @@ lapack_int LAPACK_strtri_base(
 #endif
 
 #define LAPACK_ztrtri_base LAPACK_GLOBAL(ztrtri,ZTRTRI)
-lapack_int LAPACK_ztrtri_base(
+void LAPACK_ztrtri_base(
     char const* uplo, char const* diag,
     lapack_int const* n,
     lapack_complex_double* A, lapack_int const* lda,


### PR DESCRIPTION
For some unknown historic reason, OpenBLAS has always had these as int functions unconditionally returning 0, which serves no discernible purpose and causes problems with header interoperability and LTO.

related to #6005