### PR TITLE
POWER: pass assembler CPU flags for more cores with clang on FreeBSD

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -116,6 +116,15 @@ ifeq ($(OSNAME), FreeBSD)
 ifeq ($(CORE), $(filter $(CORE),POWER9 POWER10))
 CCOMMON_OPT += -Wa,-mpwr10
 endif
+ifeq ($(CORE), POWER8)
+CCOMMON_OPT += -Wa,-mpwr8
+endif
+ifeq ($(CORE), POWER6)
+CCOMMON_OPT += -Wa,-mpwr6 -Wa,-maltivec
+endif
+ifeq ($(CORE), PPC970)
+CCOMMON_OPT += -Wa,-mpwr4 -Wa,-maltivec
+endif
 endif
 endif
 # workaround for C->FORTRAN ABI violation in LAPACKE


### PR DESCRIPTION
clang with -fno-integrated-as does not translate -mcpu into CPU
selection flags for the external assembler the way GCC's ASM_CPU_SPEC
does, so GNU as runs with bare defaults and rejects AltiVec/VSX
mnemonics, both in the hand-written kernels and in clang's own
vectorized output.  This is already handled for POWER9/POWER10 via
-Wa,-mpwr10; do the equivalent for the remaining 64-bit cores:

  POWER8:  -Wa,-mpwr8
  POWER6:  -Wa,-mpwr6 -Wa,-maltivec
  PPC970:  -Wa,-mpwr4 -Wa,-maltivec

The POWER6/PPC970 spellings match what GCC passes to the assembler
for -mcpu=power6 and -mcpu=970.  Note a lone -Wa,-maltivec is not
enough: an explicit -m option replaces the assembler's implicit
64-bit default, making it reject even lwa/mulld.

Tested on FreeBSD/powerpc64 (big-endian) with clang 19.1.7:
TARGET=PPC970 and TARGET=POWER8 both build and pass the BLAS test
suite.
