### PR TITLE
Increase blocksize for AMD server in DYNAMIC_ARCH only if CORETYPE matches AVX512

### DIFF
--- a/kernel/setparam-ref.c
+++ b/kernel/setparam-ref.c
@@ -2119,7 +2119,8 @@ static void init_parameter(void) {
     cpuid(0, &eax, &ebx, &ecx, &edx);
 
     if ((ebx == 0x68747541) && (l3_kb > 0) && (l3_kb % 32768 == 0) && (l2_kb == 1024)) { //Auth AMD
-        
+      if (strcmp(gotoblas_corename(), "cooperlake") == 0 || strcmp(gotoblas_corename(), "skylakex") == 0 || strcmp(gotoblas_corename(), "sapphirerapids") == 0) {
+
         cpuid(7, &cpuid7_eax, &cpuid7_ebx, &cpuid7_ecx, &cpuid7_edx);
         
         if (cpuid7_ebx & (1 << 16)) { // avx512 - Zen 4, 5
@@ -2141,6 +2142,7 @@ static void init_parameter(void) {
 #endif
         }
     }
+  }
 }
 #endif
 

--- a/kernel/setparam-ref.c
+++ b/kernel/setparam-ref.c
@@ -40,6 +40,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "common.h"
+extern char* gotoblas_corename(void);
 
 #ifdef BUILD_KERNEL
 #include "kernelTS.h"


### PR DESCRIPTION
Catches the case where a user-supplied OPENBLAS_CORETYPE forces a fallback to AVX2 or older assembly kernels whose internal buffers could overflow due to the unexpected blocking parameters
Fixes #6021 and probably fixes #6026 as well
